### PR TITLE
Add metadata to event classes on definition

### DIFF
--- a/lib/sourced/event.rb
+++ b/lib/sourced/event.rb
@@ -38,12 +38,13 @@ module Sourced
       @registry ||= {}
     end
 
-    def self.define(topic, &block)
+    def self.define(topic, class_metadata = {}, &block)
       klass = Class.new(self) do
         def self.name
           'Sourced::Event'
         end
       end
+      klass.define_singleton_method(:meta) { class_metadata.freeze }
       klass.define_singleton_method(:topic) { topic }
       klass.attribute :topic, Types.Value(topic).default(topic.freeze)
       if block_given?

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Sourced::Event do
     end
   end
   let(:user_created) do
-    Sourced::Event.define('users.created') do
+    Sourced::Event.define('users.created', admin: true) do
       attribute :name, Sourced::Types::String
       attribute :age, Sourced::Types::Coercible::Integer.default(40)
     end
@@ -32,6 +32,14 @@ RSpec.describe Sourced::Event do
   context 'class-level' do
     it '.topic' do
       expect(user_created.topic).to eq 'users.created'
+    end
+
+    specify '.meta' do
+      expect(user_created.meta[:admin]).to be(true)
+      expect(create_user.meta).to eq({})
+      expect {
+        create_user.meta[:foo] = 'bar'
+      }.to raise_error(FrozenError)
     end
 
     describe '.new' do


### PR DESCRIPTION
```ruby
SomeEvent = Event.define('some.event', admin_only: true)

SomeEvent.meta[admin_only] # true
```

So that we can arbitrarily filter and categorise event definitions.