### PR TITLE
Event metadata and event decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ id # UUID, required, set on creation
 stream_id # UUID, required
 created_at # Time, set on creation
 seq # Integer, usually set by stages (more on that below)
-originator_id # UUID, optional. The command or event that lead up to this event.
+metadata # Hash, custom event metadata, normally including:
+  causation_id # UUID, id of the event or command that directly caused this event
+  correlation_id # UUID, id of the event that initiated a thread or conversation.
 payload # Object, your custom event attributes.
 ```
 

--- a/lib/sourced/committer_with_prepended_events.rb
+++ b/lib/sourced/committer_with_prepended_events.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module Sourced
-  class CommitterWithOriginator
-    def initialize(originator, committable)
-      @originator = originator
+  class CommitterWithPrependedEvents
+    def initialize(committable, *events_to_prepend)
       @committable = committable
+      @events_to_prepend = events_to_prepend
     end
 
     def commit(&_block)
@@ -18,12 +18,10 @@ module Sourced
     def to_a
       @to_a ||= (
         evts = @committable.events
-        [
-          @originator.copy(seq: @committable.last_committed_seq + 1),
-          *evts.map do |evt|
-            evt.copy(originator_id: @originator.id, seq: evt.seq + 1)
-          end
-        ]
+        seq = @committable.last_committed_seq
+        (@events_to_prepend + evts).map do |evt|
+          evt.copy(seq: seq += 1)
+        end
       )
     end
   end

--- a/lib/sourced/entity_repo.rb
+++ b/lib/sourced/entity_repo.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'sourced/committer_with_originator'
+require 'sourced/committer_with_prepended_events'
 
 module Sourced
   class EntityRepo
@@ -28,8 +28,8 @@ module Sourced
       end
     end
 
-    def persist_with_originator(stage, originator_event, &block)
-      persist(CommitterWithOriginator.new(originator_event, stage), &block)
+    def persist_with_prepended_events(stage, *events_to_prepend, &block)
+      persist(CommitterWithPrependedEvents.new(stage, *events_to_prepend), &block)
     end
 
     def persist_events(events, expected_seq: nil)

--- a/lib/sourced/event.rb
+++ b/lib/sourced/event.rb
@@ -32,7 +32,6 @@ module Sourced
     attribute :seq, Types::Integer.default(1)
     attribute :created_at, Types::EventTime
     attribute :metadata, Types::Hash.default(EMPTY_HASH)
-    # attribute? :originator_id, Types::String.optional
     attribute? :payload do
 
     end
@@ -90,6 +89,13 @@ module Sourced
     def copy(new_attrs = {})
       data = to_h.merge(new_attrs)
       self.class.new(data)
+    end
+
+    def to_h
+      super.tap do |hash|
+        hash[:metadata][:causation_id] ||= id
+        hash[:metadata][:correlation_id] ||= id
+      end
     end
 
     # Like #to_h

--- a/lib/sourced/metadata_event_decorator.rb
+++ b/lib/sourced/metadata_event_decorator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Sourced
+  # And event decorator
+  # that copies and adds event metadata
+  # to all events applied by a stage
+  # Usage:
+  #
+  #   stage = SomeStage.load(id, stream).with_metadata(year: 2022)
+  #   stage.apply(SomeEvent, payload: { foo: 'bar' })
+  #   stage.events.first.metadata # includes { foo: 'bar' }
+  #
+  class MetadataEventDecorator
+    def initialize(metadata)
+      @metadata = metadata
+    end
+
+    def call(attrs)
+      meta = attrs[:metadata] || {}
+      attrs.merge(metadata: meta.merge(@metadata))
+    end
+  end
+end

--- a/lib/sourced/rspec_helpers.rb
+++ b/lib/sourced/rspec_helpers.rb
@@ -31,6 +31,8 @@ module Sourced
         event = event_constructor.new(attributes.except(:metadata))
         expect(event.causation_id).to eq(event.id)
         expect(event.correlation_id).to eq(event.id)
+        expect(event.to_h[:metadata][:causation_id]).to eq(event.id)
+        expect(event.to_h[:metadata][:causation_id]).to eq(event.id)
       end
 
       it 'is taken from metadata otherwise' do

--- a/lib/sourced/rspec_helpers.rb
+++ b/lib/sourced/rspec_helpers.rb
@@ -22,6 +22,23 @@ module Sourced
       expect(event.created_at).not_to be_nil
     end
 
+    specify '#metadata' do
+      expect(event.metadata).to be_a(Hash)
+    end
+
+    describe '#causation_id and #correlation_id' do
+      it 'defaults to event id' do
+        event = event_constructor.new(attributes.except(:metadata))
+        expect(event.causation_id).to eq(event.id)
+        expect(event.correlation_id).to eq(event.id)
+      end
+
+      it 'is taken from metadata otherwise' do
+        expect(event.causation_id).to eq(event.metadata[:causation_id])
+        expect(event.correlation_id).to eq(event.metadata[:correlation_id])
+      end
+    end
+
     specify '#to_h' do
       hash = event.to_h
       expect(hash[:topic]).to eq(event_constructor.topic)

--- a/lib/sourced/stage.rb
+++ b/lib/sourced/stage.rb
@@ -69,6 +69,20 @@ module Sourced
       @event_decorators << @seq_tracker unless @event_decorators.any?
     end
 
+    def with_event_decorator(decorator = nil, &block)
+      decorator ||= block
+
+      self.class.new(
+        id,
+        entity: entity,
+        projector: projector,
+        seq: seq,
+        last_committed_seq: last_committed_seq,
+        events: events,
+        event_decorators: event_decorators + [decorator]
+      )
+    end
+
     def ==(other)
       other.id == id && other.seq == seq
     end

--- a/lib/sourced/stage.rb
+++ b/lib/sourced/stage.rb
@@ -100,11 +100,11 @@ module Sourced
       %(<#{self.class.name}##{id} #{events.size} uncommitted events #{entity} >)
     end
 
-    def apply(event_or_class, attrs = {})
+    def apply(event_or_class, payload = {})
       event = if event_or_class.respond_to?(:copy)
         event_or_class.copy(decorate_event_attrs(event_or_class.to_h))
       else
-        event_or_class.new(decorate_event_attrs(attrs))
+        event_or_class.new(decorate_event_attrs(payload: payload))
       end
       @entity = projector.call(entity, event)
       @seq = seq_tracker.set(event.seq)

--- a/lib/sourced/stage.rb
+++ b/lib/sourced/stage.rb
@@ -66,8 +66,12 @@ module Sourced
       @last_committed_seq = last_committed_seq || seq
       @events = events
       @event_decorators = event_decorators
-      @seq_tracker = SeqTracker.new(id, seq)
-      @event_decorators << @seq_tracker unless @event_decorators.any?
+      if (seq_tracker = @event_decorators.find { |d| d.is_a?(SeqTracker) })
+        @seq_tracker = seq_tracker
+      else
+        @seq_tracker = SeqTracker.new(id, seq)
+        @event_decorators << @seq_tracker
+      end
     end
 
     def with_event_decorator(decorator = nil, &block)

--- a/lib/sourced/stage.rb
+++ b/lib/sourced/stage.rb
@@ -88,6 +88,10 @@ module Sourced
       with_event_decorator(MetadataEventDecorator.new(metadata))
     end
 
+    def following(causation_event)
+      with_metadata(causation_id: causation_event.id, correlation_id: causation_event.correlation_id)
+    end
+
     def ==(other)
       other.id == id && other.seq == seq
     end

--- a/spec/entity_repo_spec.rb
+++ b/spec/entity_repo_spec.rb
@@ -45,11 +45,6 @@ RSpec.describe Sourced::EntityRepo do
     end
   end
 
-  describe '#persist_with_originator' do
-    it 'prepends event originator to event list, updates events :originator_id' do
-    end
-  end
-
   describe '#persist_events' do
     it 'appends events to event store' do
       repo = described_class.new(stage_builder, event_store: event_store)

--- a/spec/stage_spec.rb
+++ b/spec/stage_spec.rb
@@ -111,6 +111,19 @@ RSpec.describe Sourced::Stage do
       end
     end
 
+    describe '#with_metadata' do
+      it 'adds metadata to all applied events' do
+        stream = [e1, e2, e3]
+
+        user = stage_constructor.load(id, stream).with_metadata(foo: 'bar')
+        # with event instance
+        user.apply(Sourced::UserDomain::NameChanged.new(metadata: { year: 2022 }, payload: { name: 'Ismael 2' }))
+        # with event constructor
+        user.apply(Sourced::UserDomain::AgeChanged, metadata: { lol: 'cats' }, payload: { age: 43 })
+        expect(user.events.map(&:metadata)).to eq([{ year: 2022, foo: 'bar' }, { lol: 'cats', foo: 'bar' }])
+      end
+    end
+
     describe '#commit' do
       it 'yields collected events and last committed seq, clears them from stage' do
         stream = [e1, e2, e3]

--- a/spec/stage_spec.rb
+++ b/spec/stage_spec.rb
@@ -127,10 +127,12 @@ RSpec.describe Sourced::Stage do
         user.apply(Sourced::UserDomain::AgeChanged, age: 43)
         expect(user.events.size).to eq(2)
         user.events[0].tap do |evt|
+          expect(evt.seq).to eq(4)
           expect(evt.metadata[:year]).to eq(2022)
           expect(evt.metadata[:foo]).to eq('bar')
         end
         user.events[1].tap do |evt|
+          expect(evt.seq).to eq(5)
           expect(evt.metadata[:foo]).to eq('bar')
         end
       end

--- a/spec/stage_spec.rb
+++ b/spec/stage_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Sourced::Stage do
 
         user = stage_constructor.load(id, stream)
 
-        user.apply(Sourced::UserDomain::NameChanged, payload: { name: 'Ismael 2' })
-        user.apply(Sourced::UserDomain::AgeChanged, payload: { age: 43 })
+        user.apply(Sourced::UserDomain::NameChanged, name: 'Ismael 2')
+        user.apply(Sourced::UserDomain::AgeChanged, age: 43)
 
         expect(user.id).to eq id
         expect(user.last_committed_seq).to eq 3
@@ -119,8 +119,8 @@ RSpec.describe Sourced::Stage do
         # with event instance
         user.apply(Sourced::UserDomain::NameChanged.new(metadata: { year: 2022 }, payload: { name: 'Ismael 2' }))
         # with event constructor
-        user.apply(Sourced::UserDomain::AgeChanged, metadata: { lol: 'cats' }, payload: { age: 43 })
-        expect(user.events.map(&:metadata)).to eq([{ year: 2022, foo: 'bar' }, { lol: 'cats', foo: 'bar' }])
+        user.apply(Sourced::UserDomain::AgeChanged, age: 43)
+        expect(user.events.map(&:metadata)).to eq([{ year: 2022, foo: 'bar' }, { foo: 'bar' }])
       end
     end
 
@@ -137,7 +137,7 @@ RSpec.describe Sourced::Stage do
           .with_metadata(foo: 'bar')
           .following(causation_event)
 
-        user.apply(Sourced::UserDomain::AgeChanged, metadata: { lol: 'cats' }, payload: { age: 43 })
+        user.apply(Sourced::UserDomain::AgeChanged.new(metadata: { lol: 'cats' }, payload: { age: 43 }))
         # Other decorators are still applied
         expect(user.events[0].metadata[:foo]).to eq('bar')
         expect(user.events[0].metadata[:causation_id]).to eq(causation_event.id)
@@ -151,8 +151,8 @@ RSpec.describe Sourced::Stage do
 
         user = stage_constructor.load(id, stream)
 
-        user.apply(Sourced::UserDomain::NameChanged, payload: { name: 'Ismael 2' })
-        user.apply(Sourced::UserDomain::AgeChanged, payload: { age: 43 })
+        user.apply(Sourced::UserDomain::NameChanged, name: 'Ismael 2')
+        user.apply(Sourced::UserDomain::AgeChanged, age: 43)
 
         expect(user.seq).to eq 5
         expect(user.last_committed_seq).to eq 3


### PR DESCRIPTION
A number of changes to support generic event metadata, and causation/correlation IDs.

## Event metadata

The base `Event` class now defines a `#metadata` Hash attribute.

```ruby
SomeEvent.new(stream_id: 'abc', metadata: { foo: 'bar' }, payload: {...})
```

Event stores should implement persistence for this field.

## Correlation and causation

`Event#originator_id` has been renamed to `#causation_id`, and there's a new `#correlation_id`.
Both fields are stored in `Event#metadata`, but exposed as readers. When the fields are not present in metadata, the values default to the event's ID.

`Event#follow(some_other_event)` produces a copy of an event with `#causation_id` and `#correlation_id` setup to follow another event or command.

* `#causation_id` set to the followed event's ID.
* `#correlation_id` set to the followed event's correlation_id (which might also be its ID, or a previous event's ID)

## Stage event decorators

Add a generic interface to extend event attributes when running `Stage#apply(EventClass, attrs)`

* `Stage#with_event_decorator(decorator) Stage`

Return a copy of Stage, with a new decorator in its event decorator chain, to mutate event attributes when applying new events.

The Event Decorator interface is `#call(event_attrs Hash) Hash`

```ruby
stage = SomeStage.load(stream_id, stream)
stage = stage.with_event_decorator( ->(attrs) { attrs.merge(metadata: { foo: 'bar' }) } )
stage.apply(SomeEvent, payload: {})
```

* `Stage#with_metadata(Hash) Stage` returns a stage copy setup to add metadata to every applied event.

```ruby
stage = SomeStage.load(stream_id, stream).with_metadata(user_id: 123)
stage.apply(SomeEvent, {...}) # events will have `user_id: 123` in their metadata.
```

* `Stage#following(another_event) Stage` returns a stage copy setup to add causation and correlation to every applied event.

```ruby
stage = SomeStage.load(stream_id, stream).following(command)
stage.apply(SomeEvent, {...}) # events will be set to follow command
```

All these can be combined:

```ruby
stage = stage.following(cmd).with_metadata(user_id: 123).with_decorator(...)
```

## Prepending events on commit

Use `EntityRepo#persist_with_prepended_events(stage, *Event)` to commit a stage's event prepended by some other events, with their sequence numbers corrected.
For example to prepend commands that produced the events.

```ruby
stage = stage.following(command)
stage.apply(SomeEvent, ...)

entity_repo.persist_with_prepended_events(stage, command)
```

## `Stage#apply`

`Stage#apply(event_constructor, data)` now takes the event payload data directly

Before:
```ruby
stage.apply(SomeEvent, payload: { name: 'Joe' })
```

After:
```ruby
stage.apply(SomeEvent, name: 'Joe')
```

Any event metadata can now be setup on the stage itself (ex. stage = stage.with_metadata({...})`), which will be added to all events applied to that stage instance.
