### PR TITLE
Sync reactors

### DIFF
--- a/lib/sourced/consumer.rb
+++ b/lib/sourced/consumer.rb
@@ -14,7 +14,7 @@ module Sourced
 
       attribute :group_id, Types::String.present, writer: true
       attribute :start_from, StartFrom, writer: true
-      attribute :async, Types::Boolean.default(false), writer: true
+      attribute :async, Types::Boolean.default(true), writer: true
 
       def sync!
         self.async = false

--- a/lib/sourced/consumer.rb
+++ b/lib/sourced/consumer.rb
@@ -15,6 +15,14 @@ module Sourced
       attribute :group_id, Types::String.present, writer: true
       attribute :start_from, StartFrom, writer: true
       attribute :async, Types::Boolean.default(false), writer: true
+
+      def sync!
+        self.async = false
+      end
+
+      def async!
+        self.async = true
+      end
     end
 
     def consumer_info

--- a/lib/sourced/consumer.rb
+++ b/lib/sourced/consumer.rb
@@ -14,6 +14,7 @@ module Sourced
 
       attribute :group_id, Types::String.present, writer: true
       attribute :start_from, StartFrom, writer: true
+      attribute :async, Types::Boolean.default(false), writer: true
     end
 
     def consumer_info

--- a/lib/sourced/decider.rb
+++ b/lib/sourced/decider.rb
@@ -187,7 +187,10 @@ module Sourced
     sync do |_state, command, events|
       messages = [command, *events]
       backend.append_to_stream(id, messages) if messages.any?
-      Sourced::Router.handle_events(messages)
+    end
+
+    sync do |_state, command, events|
+      Sourced::Router.handle_events(events)
     end
 
     def handle_command(command)

--- a/lib/sourced/decider.rb
+++ b/lib/sourced/decider.rb
@@ -187,6 +187,7 @@ module Sourced
     sync do |_state, command, events|
       messages = [command, *events]
       backend.append_to_stream(id, messages) if messages.any?
+      Sourced::Router.handle_events(messages)
     end
 
     def handle_command(command)

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -32,7 +32,7 @@ module Sourced
       # if they belong to different streams than the events,
       # but we need to make sure to raise exceptions in the main thread.
       # so that the transaction is rolled back.
-      def handle_events_sync(reactor, events)
+      def handle_and_ack_events_for_reactor(reactor, events)
         Sourced.config.backend.ack_on(reactor.consumer_info.group_id, events.last.id) do
           commands = reactor.handle_events(events)
           if commands && commands.any?
@@ -90,7 +90,7 @@ module Sourced
       # I need to think about how to best to handle this safely
       # Also this could potential lead to infinite recursion!
       reactors.each do |r|
-        Router.handle_events_sync(r, events)
+        Router.handle_and_ack_events_for_reactor(r, events)
       end
     end
   end

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -13,8 +13,8 @@ module Sourced
         instance.register(...)
       end
 
-      def handle(command)
-        instance.handle(command)
+      def handle_command(command)
+        instance.handle_command(command)
       end
 
       def reactors
@@ -48,7 +48,7 @@ module Sourced
       @reactors << thing
     end
 
-    def handle(command)
+    def handle_command(command)
       decider = @decider_lookup.fetch(command.class)
       decider.handle_command(command)
     end

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -7,6 +7,8 @@ module Sourced
     include Singleton
 
     class << self
+      public :new
+
       def register(...)
         instance.register(...)
       end
@@ -38,10 +40,10 @@ module Sourced
       return unless ReactorInterface === thing
 
       # TODO: we're not using this
-      thing.handled_events.each do |event_type|
-        @reactor_lookup[event_type] ||= []
-        @reactor_lookup[event_type] << thing
-      end
+      # thing.handled_events.each do |event_type|
+      #   @reactor_lookup[event_type] ||= []
+      #   @reactor_lookup[event_type] << thing
+      # end
 
       @reactors << thing
     end

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -17,16 +17,45 @@ module Sourced
         instance.handle_command(command)
       end
 
+      def handle_events(events)
+        instance.handle_events(events)
+      end
+
       def async_reactors
         instance.async_reactors
       end
+
+      # When in sync mode, we want both events
+      # and any resulting commands to be processed syncronously
+      # and in the same transaction as events are appended to store.
+      # We could handle commands in threads or fibers,
+      # if they belong to different streams than the events,
+      # but we need to make sure to raise exceptions in the main thread.
+      # so that the transaction is rolled back.
+      def handle_events_sync(reactor, events)
+        Sourced.config.backend.ack_on(reactor.consumer_info.group_id, events.last.id) do
+          commands = reactor.handle_events(events)
+          if commands && commands.any?
+            # TODO: Commands may or may not belong to he same stream as events
+            # if they belong to the same stream,
+            # hey need to be dispached in order to preserve per stream order
+            # If they belong to different streams, they can be dispatched in parallel
+            # or put in a command bus.
+            # TODO2: we also need to handle exceptions here
+            # TODO3: this is not tested
+            commands.each do |cmd|
+              Sourced::Router.handle_command(cmd)
+            end
+          end
+        end
+      end
     end
 
-    attr_reader :async_reactors
+    attr_reader :sync_reactors, :async_reactors
 
     def initialize
       @decider_lookup = {}
-      @reactor_lookup = {}
+      @sync_reactors = Set.new
       @async_reactors = Set.new
     end
 
@@ -39,18 +68,30 @@ module Sourced
 
       return unless ReactorInterface === thing
 
-      # TODO: we're not using this
-      # thing.handled_events.each do |event_type|
-      #   @reactor_lookup[event_type] ||= []
-      #   @reactor_lookup[event_type] << thing
-      # end
-
-      @async_reactors << thing
+      if thing.consumer_info.async
+        @async_reactors << thing
+      else
+        @sync_reactors << thing
+      end
     end
 
     def handle_command(command)
       decider = @decider_lookup.fetch(command.class)
       decider.handle_command(command)
+    end
+
+    def handle_events(events)
+      event_classes = events.map(&:class)
+      reactors = sync_reactors.filter do |r|
+        r.handled_events.intersect?(event_classes)
+      end
+      # TODO
+      # Reactors can return commands to run next
+      # I need to think about how to best to handle this safely
+      # Also this could potential lead to infinite recursion!
+      reactors.each do |r|
+        Router.handle_events_sync(r, events)
+      end
     end
   end
 end

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -25,35 +25,15 @@ module Sourced
         instance.async_reactors
       end
 
-      # When in sync mode, we want both events
-      # and any resulting commands to be processed syncronously
-      # and in the same transaction as events are appended to store.
-      # We could handle commands in threads or fibers,
-      # if they belong to different streams than the events,
-      # but we need to make sure to raise exceptions in the main thread.
-      # so that the transaction is rolled back.
       def handle_and_ack_events_for_reactor(reactor, events)
-        Sourced.config.backend.ack_on(reactor.consumer_info.group_id, events.last.id) do
-          commands = reactor.handle_events(events)
-          if commands && commands.any?
-            # TODO: Commands may or may not belong to he same stream as events
-            # if they belong to the same stream,
-            # hey need to be dispached in order to preserve per stream order
-            # If they belong to different streams, they can be dispatched in parallel
-            # or put in a command bus.
-            # TODO2: we also need to handle exceptions here
-            # TODO3: this is not tested
-            commands.each do |cmd|
-              Sourced::Router.handle_command(cmd)
-            end
-          end
-        end
+        instance.handle_and_ack_events_for_reactor(reactor, events)
       end
     end
 
-    attr_reader :sync_reactors, :async_reactors
+    attr_reader :sync_reactors, :async_reactors, :backend
 
-    def initialize
+    def initialize(backend: Sourced.config.backend)
+      @backend = backend
       @decider_lookup = {}
       @sync_reactors = Set.new
       @async_reactors = Set.new
@@ -90,7 +70,32 @@ module Sourced
       # I need to think about how to best to handle this safely
       # Also this could potential lead to infinite recursion!
       reactors.each do |r|
-        Router.handle_and_ack_events_for_reactor(r, events)
+        handle_and_ack_events_for_reactor(r, events)
+      end
+    end
+
+    # When in sync mode, we want both events
+    # and any resulting commands to be processed syncronously
+    # and in the same transaction as events are appended to store.
+    # We could handle commands in threads or fibers,
+    # if they belong to different streams than the events,
+    # but we need to make sure to raise exceptions in the main thread.
+    # so that the transaction is rolled back.
+    def handle_and_ack_events_for_reactor(reactor, events)
+      backend.ack_on(reactor.consumer_info.group_id, events.last.id) do
+        commands = reactor.handle_events(events)
+        if commands && commands.any?
+          # TODO: Commands may or may not belong to he same stream as events
+          # if they belong to the same stream,
+          # hey need to be dispached in order to preserve per stream order
+          # If they belong to different streams, they can be dispatched in parallel
+          # or put in a command bus.
+          # TODO2: we also need to handle exceptions here
+          # TODO3: this is not tested
+          commands.each do |cmd|
+            handle_command(cmd)
+          end
+        end
       end
     end
   end

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -94,7 +94,7 @@ module Sourced
           # TODO2: this breaks the per-stream concurrency model.
           # Ex. if the current event belongs to a 'cart1' stream,
           # the DB is locked from processing any new events for 'cart1'
-          # until we exist this block.
+          # until we exit this block.
           # if ex. reactor is a Saga that produces a command for another stream
           # (ex. 'mailer-1'), by processing the command here inline, we're blocking
           # the 'cart1' stream unnecessarily

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -17,17 +17,17 @@ module Sourced
         instance.handle_command(command)
       end
 
-      def reactors
-        instance.reactors
+      def async_reactors
+        instance.async_reactors
       end
     end
 
-    attr_reader :reactors
+    attr_reader :async_reactors
 
     def initialize
       @decider_lookup = {}
       @reactor_lookup = {}
-      @reactors = Set.new
+      @async_reactors = Set.new
     end
 
     def register(thing)
@@ -45,7 +45,7 @@ module Sourced
       #   @reactor_lookup[event_type] << thing
       # end
 
-      @reactors << thing
+      @async_reactors << thing
     end
 
     def handle_command(command)

--- a/lib/sourced/supervisor.rb
+++ b/lib/sourced/supervisor.rb
@@ -10,8 +10,7 @@ module Sourced
       new(...).start
     end
 
-    def initialize(backend: Sourced.config.backend, logger: Sourced.config.logger, count: 2)
-      @backend = backend
+    def initialize(logger: Sourced.config.logger, count: 2)
       @logger = logger
       @count = count
       @workers = []
@@ -21,7 +20,7 @@ module Sourced
       logger.info("Starting sync supervisor with #{@count} workers")
       set_signal_handlers
       @workers = @count.times.map do |i|
-        Worker.new(backend: @backend, logger:, name: "worker-#{i}")
+        Worker.new(logger:, name: "worker-#{i}")
       end
       Sync do |task|
         @workers.each do |wrk|

--- a/lib/sourced/sync.rb
+++ b/lib/sourced/sync.rb
@@ -25,22 +25,12 @@ module Sourced
     CallableInterface = Sourced::Types::Interface[:call]
 
     class SyncReactor < SimpleDelegator
+      def handle_events(events)
+        Router.handle_events_sync(__getobj__, events)
+      end
+
       def call(_state, _command, events)
-        Sourced.config.backend.ack_on(consumer_info.group_id, events.last.id) do
-          commands =  __getobj__.handle_events(events)
-          if commands && commands.any?
-            # TODO: Commands may or may not belong to he same stream as events
-            # if they belong to the same stream,
-            # hey need to be dispached in order to preserve per stream order
-            # If they belong to different streams, they can be dispatched in parallel
-            # or put in a command bus.
-            # TODO2: we also need to handle exceptions here
-            # TODO3: this is not tested
-            commands.each do |cmd|
-              Sourced::Router.handle_command(cmd)
-            end
-          end
-        end
+        handle_events(events)
       end
     end
 
@@ -59,25 +49,29 @@ module Sourced
       def sync(callable = nil, &block)
         callable ||= block
         callable = case callable
-        when Proc
-          raise ArgumentError, 'sync block must accept 2 or 3 arguments' unless (2..3).include?(callable.arity)
-          callable
-        when ReactorInterface
-          # Wrap reactors here
-          # TODO:
-          # If the sync reactor runs successfully
-          # A). we want to ACK processed events for it in the offsets table
-          # so that if the reactor is moved to async execution
-          # it doesn't reprocess the same events again
-          # B). The reactors .handle_events may return commands
-          # Do we want to dispatch those commands inline?
-          # Or is this another reason to have a separate async command bus
-          SyncReactor.new(callable)
-        when CallableInterface
-          callable
-        else
-          raise ArgumentError, 'sync block must be a Proc, Sourced::ReactorInterface or #call interface'
-        end
+                   when Proc
+                     unless (2..3).include?(callable.arity)
+                       raise ArgumentError,
+                             'sync block must accept 2 or 3 arguments'
+                     end
+
+                     callable
+                   when ReactorInterface
+                     # Wrap reactors here
+                     # TODO:
+                     # If the sync reactor runs successfully
+                     # A). we want to ACK processed events for it in the offsets table
+                     # so that if the reactor is moved to async execution
+                     # it doesn't reprocess the same events again
+                     # B). The reactors .handle_events may return commands
+                     # Do we want to dispatch those commands inline?
+                     # Or is this another reason to have a separate async command bus
+                     SyncReactor.new(callable)
+                   when CallableInterface
+                     callable
+                   else
+                     raise ArgumentError, 'sync block must be a Proc, Sourced::ReactorInterface or #call interface'
+                   end
 
         sync_blocks << callable
       end

--- a/lib/sourced/sync.rb
+++ b/lib/sourced/sync.rb
@@ -35,8 +35,9 @@ module Sourced
             # If they belong to different streams, they can be dispatched in parallel
             # or put in a command bus.
             # TODO2: we also need to handle exceptions here
+            # TODO3: this is not tested
             commands.each do |cmd|
-              Sourced::Router.handle(cmd)
+              Sourced::Router.handle_command(cmd)
             end
           end
         end

--- a/lib/sourced/sync.rb
+++ b/lib/sourced/sync.rb
@@ -26,7 +26,7 @@ module Sourced
 
     class SyncReactor < SimpleDelegator
       def handle_events(events)
-        Router.handle_events_sync(__getobj__, events)
+        Router.handle_and_ack_events_for_reactor(__getobj__, events)
       end
 
       def call(_state, _command, events)

--- a/lib/sourced/worker.rb
+++ b/lib/sourced/worker.rb
@@ -6,11 +6,11 @@ require 'sourced/router' #  comes with Async
 module Sourced
   class Worker
     def self.drain
-      new(async: false).drain
+      new.drain
     end
 
     def self.tick
-      new(async: false).tick
+      new.tick
     end
 
     attr_reader :name
@@ -19,8 +19,7 @@ module Sourced
       backend: Sourced.config.backend,
       logger: Sourced.config.logger,
       name: SecureRandom.hex(4),
-      poll_interval: 0.01,
-      async: true
+      poll_interval: 0.01
     )
       @backend = backend
       @logger = logger
@@ -88,6 +87,7 @@ module Sourced
           # We can't just run the command in a separate Fiber.
           # We want the durability of a command bus.
           # A command bus will also solve future and recurrent scheduled commands.
+          # TODO3: we need to handle multiple commands here.
           log_event(' -> produced command', reactor, commands.first)
           Sourced::Router.handle_command(commands.first)
         end

--- a/lib/sourced/worker.rb
+++ b/lib/sourced/worker.rb
@@ -40,6 +40,11 @@ module Sourced
     end
 
     def poll
+      if @reactors.empty?
+        logger.warn "Worker #{name}: No reactors to poll"
+        return false
+      end
+
       @running = true
       while @running
         tick
@@ -60,9 +65,6 @@ module Sourced
     end
 
     def tick(reactor = next_reactor)
-      # @backend.reserve_next_for(reactor.consumer_info.group_id) do |event|
-      # TODO: if reactor has empty .handled_events
-      # and it doesn't handle :any events, it should be skipped
       @backend.reserve_next_for_reactor(reactor) do |event|
         # We're dealing with one event at a time now
         # So reactors should return a single command, or nothing

--- a/lib/sourced/worker.rb
+++ b/lib/sourced/worker.rb
@@ -30,7 +30,7 @@ module Sourced
       # TODO: If reactors have a :weight, we can use that
       # to populate this array according to the weight
       # so that some reactors are picked more often than others
-      @reactors = Router.reactors.filter do |r|
+      @reactors = Router.async_reactors.filter do |r|
         r.handled_events.any?
       end.to_a.shuffle
       @reactor_index = 0

--- a/lib/sourced/worker.rb
+++ b/lib/sourced/worker.rb
@@ -89,7 +89,7 @@ module Sourced
           # We want the durability of a command bus.
           # A command bus will also solve future and recurrent scheduled commands.
           log_event(' -> produced command', reactor, commands.first)
-          Sourced::Router.handle(commands.first)
+          Sourced::Router.handle_command(commands.first)
         end
 
         event

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Sourced::Consumer do
 
         consumer do |info|
           info.group_id = 'my-group'
-          info.async = true
+          info.async!
         end
       end
 

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -61,4 +61,23 @@ RSpec.describe Sourced::Consumer do
       end
     end
   end
+
+  describe '#async' do
+    specify 'default is false' do
+      expect(TestConsumer::TestConsumer.consumer_info.async).to be(false)
+    end
+
+    it 'can be set true' do
+      klass = Class.new do
+        extend Sourced::Consumer
+
+        consumer do |info|
+          info.group_id = 'my-group'
+          info.async = true
+        end
+      end
+
+      expect(klass.consumer_info.async).to be(true)
+    end
+  end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -63,21 +63,21 @@ RSpec.describe Sourced::Consumer do
   end
 
   describe '#async' do
-    specify 'default is false' do
-      expect(TestConsumer::TestConsumer.consumer_info.async).to be(false)
+    specify 'default is true' do
+      expect(TestConsumer::TestConsumer.consumer_info.async).to be(true)
     end
 
-    it 'can be set true' do
+    it 'can be set false' do
       klass = Class.new do
         extend Sourced::Consumer
 
         consumer do |info|
           info.group_id = 'my-group'
-          info.async!
+          info.sync!
         end
       end
 
-      expect(klass.consumer_info.async).to be(true)
+      expect(klass.consumer_info.async).to be(false)
     end
   end
 end

--- a/spec/decider_spec.rb
+++ b/spec/decider_spec.rb
@@ -21,6 +21,10 @@ module TestDecider
   end
 
   class TodoListDecider < Sourced::Decider
+    consumer do |c|
+      c.async!
+    end
+
     def init_state(id)
       TodoList.new(nil, 0, id, :new, [])
     end
@@ -83,6 +87,10 @@ module TestDecider
 
   class DummyProjector
     extend Sourced::Consumer
+
+    consumer do |c|
+      c.async!
+    end
 
     class << self
       def handled_events = [WithSyncReactor::ThingDone]

--- a/spec/immediate_consistency_spec.rb
+++ b/spec/immediate_consistency_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module TestSetup
+  TodoList = Struct.new(:seq, :id, :items, :notified)
+
+  AddItem = Sourced::Message.define('imm.todos.add') do
+    attribute :name, String
+  end
+
+  Notify = Sourced::Message.define('imm.todos.notify')
+  Notified = Sourced::Message.define('imm.todos.notified')
+
+  ItemAdded = Sourced::Message.define('imm.todos.added') do
+    attribute :name, String
+  end
+
+  class TodoListDecider < Sourced::Decider
+    consumer do |c|
+      c.sync!
+    end
+
+    def init_state(id)
+      TodoList.new(0, id, [], false)
+    end
+
+    decide AddItem do |_list, cmd|
+      apply ItemAdded, name: cmd.payload.name
+    end
+
+    evolve ItemAdded do |list, event|
+      list.items << event.payload
+    end
+
+    react ItemAdded do |event|
+      event.follow(Notify)
+    end
+
+    decide Notify do |_list, _cmd|
+      apply Notified
+    end
+
+    evolve Notified do |list, _event|
+      list.notified = true
+    end
+  end
+end
+
+RSpec.describe 'Immediate consistency' do
+  before do
+    Sourced.config.backend.clear!
+    Sourced::Router.register(TestSetup::TodoListDecider)
+  end
+
+  let(:cmd) { TestSetup::AddItem.parse(stream_id: 'list1', payload: { name: 'item1' }) }
+
+  it 'runs reactor immediately' do
+    decider, _events = TestSetup::TodoListDecider.handle_command(cmd)
+    # expect(decider.state.notified).to be(true)
+    expect(TestSetup::TodoListDecider.load(decider.id).state.notified).to be(true)
+  end
+end

--- a/spec/immediate_consistency_spec.rb
+++ b/spec/immediate_consistency_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe 'Immediate consistency' do
 
   it 'runs reactor immediately' do
     decider, _events = TestSetup::TodoListDecider.handle_command(cmd)
-    # expect(decider.state.notified).to be(true)
+    decider.catch_up
+    expect(decider.state.notified).to be(true)
     expect(TestSetup::TodoListDecider.load(decider.id).state.notified).to be(true)
   end
 end

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -46,9 +46,7 @@ RSpec.describe Sourced::Router do
       router.register(RouterTest::DeciderReactor)
       cmd = RouterTest::AddItem.new
       expect(RouterTest::DeciderReactor).to receive(:handle_command).with(cmd)
-      # Change this to .handle_command
-      # So that Router quacks as a Decider
-      router.handle(cmd)
+      router.handle_command(cmd)
     end
 
     it 'registers Reactor interfaces' do

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Sourced::Router do
     it 'registers Reactor interfaces' do
       router.register(RouterTest::DeciderReactor)
       router.register(RouterTest::DeciderOnly)
-      expect(router.reactors.first).to eq(RouterTest::DeciderReactor)
+      expect(router.async_reactors.first).to eq(RouterTest::DeciderReactor)
     end
   end
 end

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe Sourced::Router do
       router.register(RouterTest::SyncReactor2)
 
       evt = RouterTest::ItemAdded.new
-      expect(Sourced::Router).to receive(:handle_events_sync).with(RouterTest::SyncReactor1, [evt])
-      expect(Sourced::Router).not_to receive(:handle_events_sync).with(RouterTest::SyncReactor2, [evt])
+      expect(Sourced::Router).to receive(:handle_and_ack_events_for_reactor).with(RouterTest::SyncReactor1, [evt])
+      expect(Sourced::Router).not_to receive(:handle_and_ack_events_for_reactor).with(RouterTest::SyncReactor2, [evt])
       router.handle_events([evt])
     end
   end

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module RouterTest
+  AddItem = Sourced::Message.define('routertest.todos.add')
+  ItemAdded = Sourced::Message.define('routertest.todos.added')
+
+  class DeciderOnly
+    extend Sourced::Consumer
+
+    # The Decider interface
+    def self.handled_commands
+      [AddItem]
+    end
+
+    def self.handle_command(_cmd); end
+  end
+
+  class DeciderReactor
+    extend Sourced::Consumer
+
+    # The Decider interface
+    def self.handled_commands
+      [AddItem]
+    end
+
+    def self.handle_command(_cmd); end
+
+    # The Reactor interface
+    def self.handled_events
+      [ItemAdded]
+    end
+
+    def self.handle_events(_evts)
+      []
+    end
+  end
+end
+
+RSpec.describe Sourced::Router do
+  subject(:router) { described_class.new }
+
+  describe '#register' do
+    it 'registers Decider interfaces' do
+      router.register(RouterTest::DeciderReactor)
+      cmd = RouterTest::AddItem.new
+      expect(RouterTest::DeciderReactor).to receive(:handle_command).with(cmd)
+      # Change this to .handle_command
+      # So that Router quacks as a Decider
+      router.handle(cmd)
+    end
+
+    it 'registers Reactor interfaces' do
+      router.register(RouterTest::DeciderReactor)
+      router.register(RouterTest::DeciderOnly)
+      expect(router.reactors.first).to eq(RouterTest::DeciderReactor)
+    end
+  end
+end

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe Sourced::Router do
       router.register(RouterTest::SyncReactor2)
 
       evt = RouterTest::ItemAdded.new
-      expect(Sourced::Router).to receive(:handle_and_ack_events_for_reactor).with(RouterTest::SyncReactor1, [evt])
-      expect(Sourced::Router).not_to receive(:handle_and_ack_events_for_reactor).with(RouterTest::SyncReactor2, [evt])
+      expect(router).to receive(:handle_and_ack_events_for_reactor).with(RouterTest::SyncReactor1, [evt])
+      expect(router).not_to receive(:handle_and_ack_events_for_reactor).with(RouterTest::SyncReactor2, [evt])
       router.handle_events([evt])
     end
   end


### PR DESCRIPTION
Add a `async` consumer config flag to make reactors sun synchronously on commit.

Deciders trigger async reactors when appending new events to backend.

Note: I might move this to the event store backend itself.

```ruby
class TodoList < Sourced::Decider
  consumer do |c|
     # .react blocks will run synchronously
     c.sync!
  end
end
```