### PR TITLE
Make Decider#apply set event #producer to decider name

### DIFF
--- a/lib/sourced/decider.rb
+++ b/lib/sourced/decider.rb
@@ -171,7 +171,11 @@ module Sourced
     end
 
     def apply(event_class, payload = {})
-      evt = __current_command.follow_with_seq(event_class, __next_sequence, payload)
+      evt = __current_command.follow_with_attributes(
+        event_class, 
+        attrs: { seq: __next_sequence, producer: self.class.consumer_info.group_id }, 
+        payload:
+      )
       uncommitted_events << evt
       evolve(state, [evt])
     end

--- a/spec/decider_spec.rb
+++ b/spec/decider_spec.rb
@@ -159,6 +159,11 @@ RSpec.describe Sourced::Decider do
       events = Sourced.config.backend.read_event_stream(cmd.stream_id)
       expect(events.map(&:seq)).to eq([1, 2, 3])
       expect(events.map(&:type)).to eq(%w[decider.todos.add decider.todos.started decider.todos.added])
+      expect(events.map(&:producer)).to eq([
+                                             nil,
+                                             TestDecider::TodoListDecider.consumer_info.group_id,
+                                             TestDecider::TodoListDecider.consumer_info.group_id
+                                           ])
     end
   end
 


### PR DESCRIPTION
Events emitted by a Decider set the event's `#producer` attribute to the Decider's group_id (ex `Carts::Inventory`).