### PR TITLE
Message metadata

### DIFF
--- a/lib/sourced/backends/sequel_backend.rb
+++ b/lib/sourced/backends/sequel_backend.rb
@@ -130,7 +130,6 @@ module Sourced
             Sequel[events_table][:global_seq],
             Sequel[events_table][:type],
             Sequel[events_table][:created_at],
-            Sequel[events_table][:producer],
             Sequel[events_table][:causation_id],
             Sequel[events_table][:correlation_id],
             Sequel[events_table][:metadata],
@@ -205,7 +204,6 @@ module Sourced
           Bignum :seq, null: false
           String :type, null: false
           Time :created_at, null: false
-          String :producer
           column :causation_id, :uuid, index: true
           column :correlation_id, :uuid
           column :metadata, :jsonb

--- a/lib/sourced/decider.rb
+++ b/lib/sourced/decider.rb
@@ -173,7 +173,8 @@ module Sourced
     def apply(event_class, payload = {})
       evt = __current_command.follow_with_attributes(
         event_class, 
-        attrs: { seq: __next_sequence, producer: self.class.consumer_info.group_id }, 
+        attrs: { seq: __next_sequence }, 
+        metadata: { producer: self.class.consumer_info.group_id },
         payload:
       )
       uncommitted_events << evt

--- a/lib/sourced/message.rb
+++ b/lib/sourced/message.rb
@@ -47,6 +47,7 @@ module Sourced
     attribute? :correlation_id, Types::UUID::V4
     attribute :producer, Types::String.nullable.default(nil)
     attribute :seq, Types::Integer.default(1)
+    attribute :metadata, Types::Hash.default(Plumb::BLANK_HASH)
     attribute :payload, Types::Static[nil]
 
     def self.registry

--- a/lib/sourced/message.rb
+++ b/lib/sourced/message.rb
@@ -106,8 +106,10 @@ module Sourced
       )
     end
 
-    def follow_with_attributes(event_class, attrs: {}, payload: nil)
-      attrs = { stream_id:, causation_id: id, correlation_id:, producer: }.merge(attrs)
+    def follow_with_attributes(event_class, attrs: {}, payload: nil, metadata: nil)
+      meta = self.metadata
+      meta = meta.merge(metadata) if metadata
+      attrs = { stream_id:, causation_id: id, correlation_id:, producer:, metadata: meta }.merge(attrs)
       attrs[:payload] = payload.to_h if payload
       event_class.parse(attrs)
     end

--- a/lib/sourced/message.rb
+++ b/lib/sourced/message.rb
@@ -45,7 +45,6 @@ module Sourced
     attribute :created_at, Types::Forms::Time.default { Time.now } #Types::JSON::AutoUTCTime
     attribute? :causation_id, Types::UUID::V4
     attribute? :correlation_id, Types::UUID::V4
-    attribute :producer, Types::String.nullable.default(nil)
     attribute :seq, Types::Integer.default(1)
     attribute :metadata, Types::Hash.default(Plumb::BLANK_HASH)
     attribute :payload, Types::Static[nil]
@@ -83,6 +82,13 @@ module Sourced
       klass.new(attrs)
     end
 
+    def with_metadata(meta = {})
+      return self if meta.empty?
+
+      attrs = metadata.merge(meta)
+      with(metadata: attrs)
+    end
+
     def follow(event_class, payload_attrs = nil)
       follow_with_attributes(
         event_class,
@@ -109,7 +115,7 @@ module Sourced
     def follow_with_attributes(event_class, attrs: {}, payload: nil, metadata: nil)
       meta = self.metadata
       meta = meta.merge(metadata) if metadata
-      attrs = { stream_id:, causation_id: id, correlation_id:, producer:, metadata: meta }.merge(attrs)
+      attrs = { stream_id:, causation_id: id, correlation_id:, metadata: meta }.merge(attrs)
       attrs[:payload] = payload.to_h if payload
       event_class.parse(attrs)
     end

--- a/lib/sourced/react.rb
+++ b/lib/sourced/react.rb
@@ -21,7 +21,7 @@ module Sourced
 
       cmds = send(method_name, event)
       [cmds].flatten.compact.map do |cmd|
-        cmd.with(producer: self.class.consumer_info.group_id)
+        cmd.with_metadata(producer: self.class.consumer_info.group_id)
       end
     end
 

--- a/spec/backends/sequel_backend_postgres_spec.rb
+++ b/spec/backends/sequel_backend_postgres_spec.rb
@@ -7,15 +7,12 @@ RSpec.describe 'Sourced::Backends::SequelBackend with Postgres', type: :backend 
   subject(:backend) { Sourced::Backends::SequelBackend.new(db) }
 
   let(:db) do
-    Sequel.postgres('sors_test')
+    Sequel.postgres('sourced_test')
   end
 
   before do
-    backend.install unless backend.installed?
-  end
-
-  after do
-    backend.clear!
+    backend.clear! if backend.installed?
+    backend.install
   end
 
   it_behaves_like 'a backend'

--- a/spec/decider_spec.rb
+++ b/spec/decider_spec.rb
@@ -159,11 +159,11 @@ RSpec.describe Sourced::Decider do
       events = Sourced.config.backend.read_event_stream(cmd.stream_id)
       expect(events.map(&:seq)).to eq([1, 2, 3])
       expect(events.map(&:type)).to eq(%w[decider.todos.add decider.todos.started decider.todos.added])
-      expect(events.map(&:producer)).to eq([
-                                             nil,
-                                             TestDecider::TodoListDecider.consumer_info.group_id,
-                                             TestDecider::TodoListDecider.consumer_info.group_id
-                                           ])
+      expect(events.map { |e| e.metadata[:producer] }).to eq([
+                                                               nil,
+                                                               TestDecider::TodoListDecider.consumer_info.group_id,
+                                                               TestDecider::TodoListDecider.consumer_info.group_id
+                                                             ])
     end
   end
 

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe Sourced::Message do
       added = add.follow(TestMessages::Added, add.payload)
       expect(added.payload.value).to eq(1)
     end
+
+    it 'copies metadata' do
+      add = TestMessages::Add.new(stream_id: '123', payload: { value: 1 }, metadata: { user_id: 10 })
+      added = add.follow(TestMessages::Added, add.payload)
+      expect(added.metadata[:user_id]).to eq(10)
+    end
   end
 
   describe '#follow_with_seq' do

--- a/spec/react_spec.rb
+++ b/spec/react_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Sourced::React do
     evt3 = ReactTestReactor::Event3.new(stream_id: '1', seq: 3)
     commands = ReactTestReactor.new.react([evt1, evt2])
     expect(commands.map(&:class)).to eq([ReactTestReactor::Cmd1, ReactTestReactor::Cmd2])
-    expect(commands.map(&:producer)).to eq(%w[ReactTestReactor ReactTestReactor])
+    expect(commands.map { |e| e.metadata[:producer] }).to eq(%w[ReactTestReactor ReactTestReactor])
   end
 
   specify '.handled_events_for_react' do


### PR DESCRIPTION
* Add `Sourced::Message#metadata` hash. 
* Make `Sourced::Message#follow` (and its variants) copy metadata from one message to another.
* Make Deciders and Reactors set `Message#metadata[:producer]` to the object's `group_id`.

![CleanShot 2024-12-03 at 12 36 36@2x](https://github.com/user-attachments/assets/d4bac919-4a3a-4094-8f5e-be8d6711bbee)
