### PR TITLE
Nested message registries

### DIFF
--- a/lib/sourced/decider.rb
+++ b/lib/sourced/decider.rb
@@ -111,7 +111,7 @@ module Sourced
         end
 
         klass_name = cmd_name.to_s.split('_').map(&:capitalize).join
-        cmd_class = Message.define(message_type, payload_schema:)
+        cmd_class = Command.define(message_type, payload_schema:)
         const_set(klass_name, cmd_class)
         decide cmd_class, &block
         define_method(cmd_name) do |**payload|

--- a/lib/sourced/message.rb
+++ b/lib/sourced/message.rb
@@ -53,6 +53,8 @@ require 'sourced/types'
 #   Message.subclasses.map(&:to_json_schema)
 #
 module Sourced
+  UnknownMessageError = Class.new(ArgumentError)
+
   class Message < Types::Data
     attribute :id, Types::AutoUUID
     attribute :stream_id, Types::String.present
@@ -119,8 +121,7 @@ module Sourced
 
     def self.from(attrs)
       klass = registry[attrs[:type]]
-      # TODO: use custom exception here
-      raise ArgumentError, "Unknown event type: #{attrs[:type]}" unless klass
+      raise UnknownMessageError, "Unknown event type: #{attrs[:type]}" unless klass
 
       klass.new(attrs)
     end

--- a/lib/sourced/message.rb
+++ b/lib/sourced/message.rb
@@ -175,4 +175,7 @@ module Sourced
       attrs
     end
   end
+
+  class Command < Message; end
+  class Event < Message; end
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Sourced::Message do
     it 'raises a known exception if no type found' do
       expect do
         Sourced::Message.from(stream_id: '123', type: 'test.unknown', payload: { value: 1 })
-      end.to raise_error(ArgumentError, 'Unknown event type: test.unknown')
+      end.to raise_error(Sourced::UnknownMessageError, 'Unknown event type: test.unknown')
     end
 
     it 'scopes message registries by sub-class' do
@@ -61,7 +61,7 @@ RSpec.describe Sourced::Message do
 
       expect do
         TestMessages::Command.from(stream_id: '123', type: 'test.added', payload: { value: 1 })
-      end.to raise_error(ArgumentError, 'Unknown event type: test.added')
+      end.to raise_error(Sourced::UnknownMessageError, 'Unknown event type: test.added')
     end
   end
 

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -3,7 +3,9 @@
 require 'spec_helper'
 
 module TestMessages
-  Add = Sourced::Message.define('test.add') do
+  Command = Class.new(Sourced::Message)
+
+  Add = Command.define('test.add') do
     attribute :value, Integer
   end
 
@@ -51,6 +53,15 @@ RSpec.describe Sourced::Message do
       expect do
         Sourced::Message.from(stream_id: '123', type: 'test.unknown', payload: { value: 1 })
       end.to raise_error(ArgumentError, 'Unknown event type: test.unknown')
+    end
+
+    it 'scopes message registries by sub-class' do
+      msg = TestMessages::Command.from(stream_id: '123', type: 'test.add', payload: { value: 1 })
+      expect(msg).to be_a(TestMessages::Add)
+
+      expect do
+        TestMessages::Command.from(stream_id: '123', type: 'test.added', payload: { value: 1 })
+      end.to raise_error(ArgumentError, 'Unknown event type: test.added')
     end
   end
 


### PR DESCRIPTION
Make `Sourced::Message` subclasses have their own registries, so that we can scope message class lookup by class.

Parent classes have access to all subclasses and their registries.

So that we can restrict clients to only instantiating subsets of command or event classes.

Also introduce `Sourced::Command` and `Sourced::Event` subclasses.

```ruby
class PublicCommand < Sourced::Message; end
class PrivateCommand < Sourced::Message; end
 
DoSomething = PublicCommand.define('commands.do_something')

# Use .from scoped to PublicCommand subclass
# to ensure that only PublicCommand subclasses are accessible.
cmd = PublicCommand.from(type: 'commands.do_something', payload: { ... })

# This also works
cmd = Sourced::Message.from(type: 'commands.do_something', payload: { ... })

# This raises a Sourced::UnknownMessage exception
cmd = PrivateCommand.from(type: 'commands.do_something', payload: { ... })
```