### PR TITLE
Command context

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     sourced (0.1.0)
       async
-      plumb (>= 0.0.8)
+      plumb (>= 0.0.9)
 
 GEM
   remote: https://rubygems.org/
@@ -59,7 +59,7 @@ GEM
     mini_portile2 (2.8.7)
     minitest (5.25.1)
     pg (1.5.8)
-    plumb (0.0.8)
+    plumb (0.0.9)
       bigdecimal
       concurrent-ruby
     psych (5.1.2)

--- a/lib/sourced.rb
+++ b/lib/sourced.rb
@@ -37,4 +37,5 @@ require 'sourced/router'
 require 'sourced/message'
 require 'sourced/decider'
 require 'sourced/supervisor'
+require 'sourced/command_context'
 require 'sourced/rails/railtie' if defined?(Rails::Railtie)

--- a/lib/sourced/command_context.rb
+++ b/lib/sourced/command_context.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'sourced/types'
+
+module Sourced
+  # A command factory to instantiate commands from Hash attributes
+  # including extra metadata.
+  # @example
+  #
+  #  ctx = Sourced::CommandContext.new(
+  #    stream_id: params[:stream_id],
+  #    metadata: {
+  #      user_id: session[:user_id]
+  #    }
+  #  )
+  #
+  # # params[:command] should be a Hash with { type: String, payload: Hash | nil }
+  #
+  #  cmd = ctx.build(params[:command])
+  #  cmd.stream_id # String
+  #  cmd.metadata[:user_id] # == session[:user_id]
+  #
+  class CommandContext
+    # @option stream_id [String]
+    # @option metadata [Hash] metadata to add to commands built by this context
+    # @option scope [Sourced::Message] Message class to use as command registry
+    def initialize(stream_id: nil, metadata: Plumb::BLANK_HASH, scope: Sourced::Command)
+      @defaults = {
+        stream_id:,
+        metadata:
+      }.freeze
+      @scope = scope
+    end
+
+    # @param attrs [Hash] attributes to lookup and buils a scope from.
+    # @return [Sourced::Message]
+    def build(attrs)
+      attrs = defaults.merge(Types::SymbolizedHash.parse(attrs))
+      scope.from(attrs)
+    end
+
+    private
+
+    attr_reader :defaults, :scope
+  end
+end

--- a/lib/sourced/types.rb
+++ b/lib/sourced/types.rb
@@ -10,5 +10,15 @@ module Sourced
 
     # A UUID string, or generate a new one
     AutoUUID = UUID::V4.default { SecureRandom.uuid }
+
+    # Deeply symbolize keys of a hash
+    # Usage:
+    #   SymbolizedHash.parse({ 'a' => { 'b' => 'c' } }) # => { a: { b: 'c' } }
+    SymbolizedHash = Hash[
+      # String keys are converted to symbols
+      (Symbol | String.transform(::Symbol, &:to_sym)),
+      # Hash values are recursively symbolized
+      Any.defer { SymbolizedHash } | Any
+    ]
   end
 end

--- a/sourced.gemspec
+++ b/sourced.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'async'
-  spec.add_dependency 'plumb', '>= 0.0.8'
+  spec.add_dependency 'plumb', '>= 0.0.9'
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/spec/command_context_spec.rb
+++ b/spec/command_context_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module ContextTest
+  Add = Sourced::Command.define('ctest.add') do
+    attribute :value, Integer
+  end
+
+  Added = Sourced::Event.define('ctest.added')
+end
+
+RSpec.describe Sourced::CommandContext do
+  describe '#build' do
+    it 'builds command with stream_id and metadata' do
+      ctx = described_class.new(stream_id: '123', metadata: { user_id: 10 })
+      cmd = ctx.build(type: 'ctest.add', payload: { value: 1 })
+      expect(cmd).to be_a(ContextTest::Add)
+      expect(cmd.stream_id).to eq('123')
+      expect(cmd.payload.value).to eq(1)
+      expect(cmd.metadata[:user_id]).to eq(10)
+    end
+
+    it 'allows overriding stream_id' do
+      ctx = described_class.new(stream_id: '123', metadata: { user_id: 10 })
+      cmd = ctx.build(stream_id: 'aaa', type: 'ctest.add', payload: { value: 1 })
+      expect(cmd.stream_id).to eq('aaa')
+    end
+
+    it 'symbolizes attributes' do
+      ctx = described_class.new(stream_id: '123', metadata: { user_id: 10 })
+      cmd = ctx.build('type' => 'ctest.add', 'payload' => { 'value' => 1 })
+      expect(cmd).to be_a(ContextTest::Add)
+      expect(cmd.stream_id).to eq('123')
+      expect(cmd.payload.value).to eq(1)
+      expect(cmd.metadata[:user_id]).to eq(10)
+    end
+
+    it 'raises an exception if command type does not exist' do
+      ctx = described_class.new(stream_id: '123', metadata: { user_id: 10 })
+      expect do
+        ctx.build('type' => 'nope', 'payload' => { 'value' => 1 })
+      end.to raise_error(Sourced::UnknownMessageError)
+    end
+
+    it 'raises an exception if command type does not exist in scope class' do
+      ctx = described_class.new(stream_id: '123', metadata: { user_id: 10 })
+      expect do
+        ctx.build('type' => 'ctest.added', 'payload' => { 'value' => 1 })
+      end.to raise_error(Sourced::UnknownMessageError)
+    end
+  end
+end


### PR DESCRIPTION
A command factory to instantiate commands from Hash attributes
including extra metadata.

```ruby
ctx = Sourced::CommandContext.new(
  stream_id: params[:stream_id],
  metadata: {
    user_id: session[:user_id]
  }
)

# params[:command] should be a Hash with { type: String, payload: Hash | nil }

cmd = ctx.build(params[:command])
cmd.stream_id # String
cmd.metadata[:user_id] # == session[:user_id]
 ```
