### PR TITLE
Projectors

### DIFF
--- a/lib/sourced.rb
+++ b/lib/sourced.rb
@@ -36,6 +36,7 @@ require 'sourced/configuration'
 require 'sourced/router'
 require 'sourced/message'
 require 'sourced/decider'
+require 'sourced/projector'
 require 'sourced/supervisor'
 require 'sourced/command_context'
 require 'sourced/rails/railtie' if defined?(Rails::Railtie)

--- a/lib/sourced/projector.rb
+++ b/lib/sourced/projector.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Sourced
+  class Projector
+    include Evolve
+    include Sync
+    extend Consumer
+
+    class << self
+      def handled_events = handled_events_for_evolve
+    end
+
+    attr_reader :id, :state
+
+    def initialize(id, backend: Sourced.config.backend, logger: Sourced.config.logger)
+      @id = id
+      @backend = backend
+      @logger = logger
+      @state = init_state(id)
+    end
+
+    def inspect
+      %(<#{self.class} id:#{id} seq:#{seq}>)
+    end
+
+    def handle_events(events)
+      evolve(state, events)
+      save
+      [] # no commands
+    end
+
+    private
+
+    attr_reader :backend, :logger
+
+    def init_state(_id)
+      nil
+    end
+
+    def save
+      backend.transaction do
+        run_sync_blocks(state, nil, [])
+      end
+    end
+
+    class StateStored < self
+      class << self
+        def handle_events(events)
+          instance = new(events.first.stream_id)
+          instance.handle_events(events)
+        end
+      end
+    end
+  end
+end

--- a/spec/projector_spec.rb
+++ b/spec/projector_spec.rb
@@ -24,6 +24,20 @@ module ProjectorTest
       STORE[state.id] = state
     end
   end
+
+  class EventSourced < Sourced::Projector::EventSourced
+    def init_state(id)
+      State.new(id, 0)
+    end
+
+    evolve Added do |state, event|
+      state.total += event.payload.amount
+    end
+
+    sync do |state, _, _events|
+      STORE[state.id] = state
+    end
+  end
 end
 
 RSpec.describe Sourced::Projector do
@@ -50,6 +64,31 @@ RSpec.describe Sourced::Projector do
       ProjectorTest::StateStored.handle_events([e1, e2])
 
       expect(ProjectorTest::STORE['111'].total).to eq(25)
+    end
+  end
+
+  describe Sourced::Projector::EventSourced do
+    specify 'with no previous events' do
+      e1 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 10 })
+      e2 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 5 })
+
+      result = ProjectorTest::EventSourced.handle_events([e1, e2])
+
+      expect(result).to eq([])
+      expect(ProjectorTest::STORE['111'].total).to eq(15)
+    end
+
+    specify 'with previous events' do
+      e1 = ProjectorTest::Added.parse(stream_id: '111', seq: 1, payload: { amount: 10 })
+      e2 = ProjectorTest::Added.parse(stream_id: '111', seq: 2, payload: { amount: 5 })
+      e3 = ProjectorTest::Added.parse(stream_id: '111', seq: 3, payload: { amount: 7 })
+
+      Sourced.config.backend.append_to_stream('111', [e1])
+
+      result = ProjectorTest::EventSourced.handle_events([e2, e3])
+
+      expect(result).to eq([])
+      expect(ProjectorTest::STORE['111'].total).to eq(22)
     end
   end
 end

--- a/spec/projector_spec.rb
+++ b/spec/projector_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe Sourced::Projector do
   end
 
   describe Sourced::Projector::StateStored do
+    it 'has consumer info' do
+      expect(ProjectorTest::StateStored.consumer_info.group_id).to eq('ProjectorTest::StateStored')
+    end
+
     specify 'with new state' do
       e1 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 10 })
       e2 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 5 })
@@ -68,6 +72,10 @@ RSpec.describe Sourced::Projector do
   end
 
   describe Sourced::Projector::EventSourced do
+    it 'has consumer info' do
+      expect(ProjectorTest::EventSourced.consumer_info.group_id).to eq('ProjectorTest::EventSourced')
+    end
+
     specify 'with no previous events' do
       e1 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 10 })
       e2 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 5 })

--- a/spec/projector_spec.rb
+++ b/spec/projector_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module ProjectorTest
+  STORE = {}
+
+  State = Struct.new(:id, :total)
+
+  Added = Sourced::Event.define('prtest.added') do
+    attribute :amount, Integer
+  end
+
+  class StateStored < Sourced::Projector::StateStored
+    def init_state(id)
+      STORE[id] || State.new(id, 0)
+    end
+
+    evolve Added do |state, event|
+      state.total += event.payload.amount
+    end
+
+    sync do |state, _, _events|
+      STORE[state.id] = state
+    end
+  end
+end
+
+RSpec.describe Sourced::Projector do
+  before do
+    ProjectorTest::STORE.clear
+  end
+
+  describe Sourced::Projector::StateStored do
+    specify 'with new state' do
+      e1 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 10 })
+      e2 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 5 })
+
+      ProjectorTest::StateStored.handle_events([e1, e2])
+
+      expect(ProjectorTest::STORE['111'].total).to eq(15)
+    end
+
+    specify 'with existing state' do
+      ProjectorTest::STORE['111'] = ProjectorTest::State.new('111', 10)
+
+      e1 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 10 })
+      e2 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 5 })
+
+      ProjectorTest::StateStored.handle_events([e1, e2])
+
+      expect(ProjectorTest::STORE['111'].total).to eq(25)
+    end
+  end
+end


### PR DESCRIPTION
Implement two projector classes for common use cases.

### State Stored projector
A State Stored projector fetches initial state from
storage somewhere (DB, files, API)
And then after reacting to events and updating state,
it can save it back to the same or different storage.

```ruby
class CartListings < Sourced::Projector::StateStored
  # Fetch listing record from DB, or new one.
  def init_state(id)
    CartListing.find_or_initialize(id)
  end

  # Evolve listing record from events
  evolve Carts::ItemAdded do |listing, event|
    listing.total += event.payload.price
  end

  # Sync listing record back to DB
  sync do |listing, _, _|
    listing.save!
  end
end
```

### Event Sourced projector
An Event Sourced projector fetches initial state from past events in the event store.
And then after reacting to events and updating state,
it can save it to a DB table, a file, etc.

```ruby
class CartListings < Sourced::Projector::EventSourced
  # Initial in-memory state
  def init_state(id)
    { id:, total: 0 }
  end

  # Evolve listing record from events
  evolve Carts::ItemAdded do |listing, event|
    listing[:total] += event.payload.price
  end

  # Sync listing record to a file
  sync do |listing, _, _|
    File.write("/listings/#{listing[:id]}.json", JSON.dump(listing)) 
  end
end
```
