### PR TITLE
Backend read correlation batch

### DIFF
--- a/lib/sourced/backends/sequel_backend.rb
+++ b/lib/sourced/backends/sequel_backend.rb
@@ -152,16 +152,6 @@ module Sourced
         end
       end
 
-      def read_event_batch(causation_id)
-        query = base_events_query
-          .where(Sequel[events_table][:causation_id] => causation_id)
-          .order(Sequel[events_table][:global_seq])
-
-        query.map do |row|
-          deserialize_event(row)
-        end
-      end
-
       def read_event_stream(stream_id, after: nil, upto: nil)
         _events_table = events_table # need local variable for Sequel block
 

--- a/lib/sourced/backends/sequel_backend.rb
+++ b/lib/sourced/backends/sequel_backend.rb
@@ -138,6 +138,20 @@ module Sourced
           .join(streams_table, id: :stream_id)
       end
 
+      def read_correlation_batch(event_id)
+        correlation_subquery = db[events_table]
+          .select(:correlation_id)
+          .where(id: event_id)
+
+        query = base_events_query
+          .where(Sequel[events_table][:correlation_id] => correlation_subquery)
+          .order(Sequel[events_table][:global_seq])
+
+        query.map do |row|
+          deserialize_event(row)
+        end
+      end
+
       def read_event_batch(causation_id)
         query = base_events_query
           .where(Sequel[events_table][:causation_id] => causation_id)

--- a/lib/sourced/backends/test_backend.rb
+++ b/lib/sourced/backends/test_backend.rb
@@ -98,12 +98,11 @@ module Sourced
       end
 
       class State
-        attr_reader :events, :groups, :events_by_causation_id, :events_by_correlation_id, :events_by_stream_id, :stream_id_seq_index
+        attr_reader :events, :groups, :events_by_correlation_id, :events_by_stream_id, :stream_id_seq_index
 
         def initialize(
           events: [], 
           groups: Hash.new { |h, k| h[k] = Group.new(k, self) }, 
-          events_by_causation_id: Hash.new { |h, k| h[k] = [] }, 
           events_by_correlation_id: Hash.new { |h, k| h[k] = [] }, 
           events_by_stream_id: Hash.new { |h, k| h[k] = [] },
           stream_id_seq_index: {}
@@ -111,7 +110,6 @@ module Sourced
 
           @events = events
           @groups = groups
-          @events_by_causation_id = events_by_causation_id
           @events_by_correlation_id = events_by_correlation_id
           @events_by_stream_id = events_by_stream_id
           @stream_id_seq_index = stream_id_seq_index
@@ -121,7 +119,6 @@ module Sourced
           self.class.new(
             events: events.dup,
             groups: deep_dup(groups),
-            events_by_causation_id: deep_dup(events_by_causation_id),
             events_by_correlation_id: deep_dup(events_by_correlation_id),
             events_by_stream_id: deep_dup(events_by_stream_id),
             stream_id_seq_index: deep_dup(stream_id_seq_index)
@@ -190,7 +187,6 @@ module Sourced
           check_unique_seq!(events)
 
           events.each do |event|
-            @state.events_by_causation_id[event.causation_id] << event
             @state.events_by_correlation_id[event.correlation_id] << event
             @state.events_by_stream_id[stream_id] << event
             @state.events << event
@@ -199,10 +195,6 @@ module Sourced
         end
         @state.groups.each_value(&:reindex)
         true
-      end
-
-      def read_event_batch(causation_id)
-        @state.events_by_causation_id[causation_id]
       end
 
       def read_correlation_batch(event_id)

--- a/lib/sourced/configuration.rb
+++ b/lib/sourced/configuration.rb
@@ -11,7 +11,7 @@ module Sourced
       :installed?,
       :reserve_next_for_reactor,
       :append_to_stream,
-      :read_event_batch,
+      :read_correlation_batch,
       :read_event_stream,
       :transaction
     ]

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Sourced::Configuration do
         :installed?,
         :reserve_next_for_reactor,
         :append_to_stream,
-        :read_event_batch,
+        :read_correlation_batch,
         :read_event_stream,
         :transaction
       )

--- a/spec/shared_examples/backend_examples.rb
+++ b/spec/shared_examples/backend_examples.rb
@@ -311,18 +311,7 @@ module BackendExamples
       end
     end
 
-    describe '#append_to_stream, #read_event_batch' do
-      it 'reads event batch by causation_id' do
-        cmd1 = Tests::DoSomething.parse(stream_id: 's1', seq: 1, payload: { account_id: 1 })
-        evt1 = cmd1.follow_with_seq(Tests::SomethingHappened1, 2, account_id: cmd1.payload.account_id)
-        evt2 = cmd1.follow_with_seq(Tests::SomethingHappened1, 3, account_id: cmd1.payload.account_id)
-        evt3 = Tests::SomethingHappened1.parse(stream_id: 's1', seq: 4, payload: { account_id: 1 })
-        expect(backend.append_to_stream('s1', [evt1, evt2, evt3])).to be(true)
-
-        events = backend.read_event_batch(cmd1.id)
-        expect(events).to eq([evt1, evt2])
-      end
-
+    describe '#append_to_stream' do
       it 'fails if duplicate [stream_id, seq]' do
         evt1 = Tests::SomethingHappened1.parse(stream_id: 's1', seq: 1, payload: { account_id: 1 })
         evt2 = Tests::SomethingHappened1.parse(stream_id: 's1', seq: 1, payload: { account_id: 1 })


### PR DESCRIPTION
Add `Backend#read_correlation_batch(event_id) => Array<Sourced::Message>`.

It takes an event ID and returns a list of ordered events sharing the initial event's `correlation_id`.

![event-correlation-view](https://github.com/user-attachments/assets/c8d07095-2af0-46f5-a21a-f6b1e834b77e)

Useful to trace the full cause-and-effect of a command, starting from any of its correlated events.