### PR TITLE
Scheduled commands

### DIFF
--- a/lib/sourced/backends/sequel_backend.rb
+++ b/lib/sourced/backends/sequel_backend.rb
@@ -254,7 +254,6 @@ module Sourced
               SELECT 
                   id,
                   stream_id,
-                  stream_id,
                   type,
                   causation_id,
                   correlation_id,

--- a/lib/sourced/backends/sequel_backend.rb
+++ b/lib/sourced/backends/sequel_backend.rb
@@ -36,6 +36,10 @@ module Sourced
         true
       end
 
+      # TODO: if the application raises an exception
+      # the command row is not deleted, so that it can be retried.
+      # However, if a command fails _permanently_ there's no point in keeping it in the queue,
+      # this ties with unresolved error handling in event handling, too.
       def next_command(&reserve)
         if block_given?
           db.transaction do

--- a/lib/sourced/backends/sequel_backend.rb
+++ b/lib/sourced/backends/sequel_backend.rb
@@ -14,6 +14,7 @@ module Sourced
         @db = connect(db)
         @logger = logger
         @prefix = prefix
+        @commands_table = table_name(:commands)
         @streams_table = table_name(:streams)
         @offsets_table = table_name(:offsets)
         @events_table = table_name(:events)
@@ -21,27 +22,23 @@ module Sourced
       end
 
       def installed?
-        db.table_exists?(events_table) && db.table_exists?(streams_table) && db.table_exists?(offsets_table)
+        db.table_exists?(events_table) && db.table_exists?(streams_table) && db.table_exists?(offsets_table) && db.table_exists?(commands_table)
       end
 
       def schedule_commands(commands)
         return false if commands.empty?
 
-        # TODO: here we could use multi_insert
-        # for both streams and commands
+        rows = commands.map { |c| serialize_command(c) }
+
         db.transaction do
-          commands.each do |command|
-            schedule_command(command.stream_id, command)
-          end
+          db[commands_table].multi_insert(rows)
         end
         true
       end
 
-      def schedule_command(stream_id, command)
-        db.transaction do
-          db[streams_table].insert_conflict.insert(stream_id:)
-          db[commands_table].insert(stream_id:, data: command.to_json)
-        end
+      def next_command
+        row = db[commands_table].order(:created_at).first
+        row ? deserialize_event(row) : nil
       end
 
       Stats = Data.define(:stream_count, :max_global_seq, :groups)
@@ -170,6 +167,7 @@ module Sourced
         # Truncate and restart global_seq increment first
         db[events_table].truncate(cascade: true, only: true, restart: true)
         db[events_table].delete
+        db[commands_table].delete
         db[offsets_table].delete
         db[streams_table].delete
       end
@@ -217,12 +215,25 @@ module Sourced
 
         logger.info("Created table #{events_table}")
 
+        db.create_table?(commands_table) do
+          column :id, :uuid, unique: true
+          String :stream_id, null: false, index: true
+          String :type, null: false
+          Time :created_at, null: false, index: true
+          column :causation_id, :uuid
+          column :correlation_id, :uuid
+          column :metadata, :jsonb
+          column :payload, :jsonb
+        end
+
+        logger.info("Created table #{commands_table}")
+
         self
       end
 
       private
 
-      attr_reader :db, :logger, :prefix, :events_table, :streams_table, :offsets_table
+      attr_reader :db, :logger, :prefix, :events_table, :streams_table, :offsets_table, :commands_table
 
       def sql_for_reserve_next_with_events(handled_events, with_time_window = false)
         event_types = handled_events.map { |e| "'#{e}'" }
@@ -296,6 +307,13 @@ module Sourced
         return json unless json.is_a?(String)
 
         JSON.parse(json, symbolize_names: true)
+      end
+
+      def serialize_command(cmd)
+        row = cmd.to_h.except(:seq)
+        row[:metadata] = JSON.dump(row[:metadata]) if row[:metadata]
+        row[:payload] = JSON.dump(row[:payload]) if row[:payload]
+        row
       end
 
       def serialize_event(event, stream_id)

--- a/lib/sourced/backends/test_backend.rb
+++ b/lib/sourced/backends/test_backend.rb
@@ -98,10 +98,11 @@ module Sourced
       end
 
       class State
-        attr_reader :events, :groups, :events_by_correlation_id, :events_by_stream_id, :stream_id_seq_index
+        attr_reader :events, :commands, :groups, :events_by_correlation_id, :events_by_stream_id, :stream_id_seq_index
 
         def initialize(
           events: [], 
+          commands: [],
           groups: Hash.new { |h, k| h[k] = Group.new(k, self) }, 
           events_by_correlation_id: Hash.new { |h, k| h[k] = [] }, 
           events_by_stream_id: Hash.new { |h, k| h[k] = [] },
@@ -111,13 +112,33 @@ module Sourced
           @events = events
           @groups = groups
           @events_by_correlation_id = events_by_correlation_id
+          @commands = commands
           @events_by_stream_id = events_by_stream_id
           @stream_id_seq_index = stream_id_seq_index
+        end
+
+        def schedule_commands(commands)
+          @commands = (@commands + commands).sort_by(&:created_at)
+        end
+
+        def next_command(&reserve)
+          now = Time.now.utc
+
+          if block_given?
+            return nil if @commands.empty?
+            return nil if @commands.first.created_at > now
+            cmd = @commands.shift
+            yield cmd
+            cmd
+          else
+            @commands.first
+          end
         end
 
         def copy
           self.class.new(
             events: events.dup,
+            commands: commands.dup,
             groups: deep_dup(groups),
             events_by_correlation_id: deep_dup(events_by_correlation_id),
             events_by_stream_id: deep_dup(events_by_stream_id),
@@ -151,6 +172,18 @@ module Sourced
         transaction do
           group = @state.groups[group_id]
           group.ack_on(event_id, &)
+        end
+      end
+
+      def schedule_commands(commands)
+        transaction do
+          @state.schedule_commands(commands)
+        end
+      end
+
+      def next_command(&)
+        transaction do
+          @state.next_command(&)
         end
       end
 

--- a/lib/sourced/configuration.rb
+++ b/lib/sourced/configuration.rb
@@ -14,6 +14,7 @@ module Sourced
       :read_correlation_batch,
       :read_event_stream,
       :schedule_commands,
+      :next_command,
       :transaction
     ]
 

--- a/lib/sourced/configuration.rb
+++ b/lib/sourced/configuration.rb
@@ -13,6 +13,7 @@ module Sourced
       :append_to_stream,
       :read_correlation_batch,
       :read_event_stream,
+      :schedule_commands,
       :transaction
     ]
 

--- a/lib/sourced/message.rb
+++ b/lib/sourced/message.rb
@@ -54,6 +54,7 @@ require 'sourced/types'
 #
 module Sourced
   UnknownMessageError = Class.new(ArgumentError)
+  PastMessageDateError = Class.new(ArgumentError)
 
   class Message < Types::Data
     attribute :id, Types::AutoUUID
@@ -162,6 +163,13 @@ module Sourced
       attrs = { stream_id:, causation_id: id, correlation_id:, metadata: meta }.merge(attrs)
       attrs[:payload] = payload.to_h if payload
       event_class.parse(attrs)
+    end
+
+    def delay(datetime)
+      if datetime < created_at
+        raise PastMessageDateError, "Message #{type} can't be delayed to a date in the past"
+      end
+      with(created_at: datetime)
     end
 
     def to_json(*)

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -19,6 +19,10 @@ module Sourced
         instance.handle_command(command)
       end
 
+      def dispatch_next_command
+        instance.dispatch_next_command
+      end
+
       def handle_events(events)
         instance.handle_events(events)
       end
@@ -91,25 +95,7 @@ module Sourced
           # This will run a new decider
           # which may be expensive, timeout, or raise an exception
           # TODO: handle decider errors
-          # TODO2: this breaks the per-stream concurrency model.
-          # Ex. if the current event belongs to a 'cart1' stream,
-          # the DB is locked from processing any new events for 'cart1'
-          # until we exit this block.
-          # if ex. reactor is a Saga that produces a command for another stream
-          # (ex. 'mailer-1'), by processing the command here inline, we're blocking
-          # the 'cart1' stream unnecessarily
-          # Instead, we can:
-          # if command.stream_id == event.stream_id
-          # * it's Ok to block, as we keep per-stream concurrency
-          # if command.stream_id != event.stream_id
-          # * we should schedule the command to be picked up later.
-          # We can't just run the command in a separate Fiber.
-          # We want the durability of a command bus.
-          # A command bus will also solve future and recurrent scheduled commands.
-          commands.each do |cmd|
-            log_event(' -> produced command', reactor, cmd, process_name)
-            handle_command(cmd)
-          end
+          backend.schedule_commands(commands)
         end
 
         event
@@ -139,6 +125,13 @@ module Sourced
             handle_command(cmd)
           end
         end
+      end
+    end
+
+    def dispatch_next_command
+      backend.next_command do |cmd|
+        #  TODO: error handling
+        handle_command(cmd)
       end
     end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Sourced::Configuration do
         :append_to_stream,
         :read_correlation_batch,
         :read_event_stream,
+        :schedule_commands,
         :transaction
       )
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Sourced::Configuration do
         :read_correlation_batch,
         :read_event_stream,
         :schedule_commands,
+        :next_command,
         :transaction
       )
 

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -105,4 +105,19 @@ RSpec.describe Sourced::Message do
       expect(added.correlation_id).to eq(add.id)
     end
   end
+
+  describe '#delay' do
+    it 'creates a message with a created_at date in the future' do
+      add = TestMessages::Add.new(stream_id: '123', payload: { value: 1 })
+      delayed = add.delay(add.created_at + 10)
+      expect(delayed.created_at).to eq(add.created_at + 10)
+    end
+
+    it 'does not allow setting a date lower than current' do
+      add = TestMessages::Add.new(stream_id: '123', payload: { value: 1 })
+      expect do
+        add.delay(add.created_at - 10)
+      end.to raise_error(Sourced::PastMessageDateError)
+    end
+  end
 end

--- a/spec/shared_examples/backend_examples.rb
+++ b/spec/shared_examples/backend_examples.rb
@@ -70,6 +70,15 @@ module BackendExamples
       end
     end
 
+    describe '#schedule_commands' do
+      it 'schedules command' do
+        cmd = Tests::DoSomething.parse(stream_id: 's1', payload: { account_id: 1 })
+        backend.schedule_commands([cmd])
+        cmd2 = backend.next_command
+        expect(cmd2).to eq(cmd)
+      end
+    end
+
     describe '#append_to_stream and #reserve_next_for_reactor' do
       it 'supports a time window' do
         now = Time.now

--- a/spec/shared_examples/backend_examples.rb
+++ b/spec/shared_examples/backend_examples.rb
@@ -89,6 +89,19 @@ module BackendExamples
         expect(backend.next_command).to be(nil)
       end
 
+      it 'does not delete command if processing raises' do
+        cmd = Tests::DoSomething.parse(stream_id: 's1', payload: { account_id: 1 })
+        backend.schedule_commands([cmd])
+        begin
+          backend.next_command do |_c|
+            raise 'nope!'
+          end
+        rescue StandardError
+          nil
+        end
+        expect(backend.next_command).to eq(cmd)
+      end
+
       it 'blocks concurrent workers from processing the same command' do
         now = Time.now - 10
         cmd1 = Tests::DoSomething.parse(stream_id: 's1', created_at: now, payload: { account_id: 1 })

--- a/spec/shared_examples/backend_examples.rb
+++ b/spec/shared_examples/backend_examples.rb
@@ -103,18 +103,21 @@ module BackendExamples
       end
 
       it 'blocks concurrent workers from processing the same command' do
+        # backend.send(:db)[:sourced_commands].delete
         now = Time.now - 10
-        cmd1 = Tests::DoSomething.parse(stream_id: 's1', created_at: now, payload: { account_id: 1 })
-        cmd2 = Tests::DoSomething.parse(stream_id: 's2', created_at: now + 5, payload: { account_id: 1 })
+        cmd1 = Tests::DoSomething.parse(stream_id: 'as1', created_at: now, payload: { account_id: 1 })
+        cmd2 = Tests::DoSomething.parse(stream_id: 'as2', created_at: now + 5, payload: { account_id: 1 })
         backend.schedule_commands([cmd1, cmd2])
-        results = []
-        backend.next_command do |c|
-          backend.next_command do |c|
-            results << c
+        results = Concurrent::Array.new
+        2.times.map do
+          Thread.new do
+            backend.next_command do |c|
+              sleep 0.01
+              results << c
+            end
           end
-          results << c
-        end
-        expect(results).to eq([cmd2, cmd1])
+        end.map(&:join)
+        expect(results).to match_array([cmd2, cmd1])
       end
 
       it 'processes commands at a later time' do
@@ -141,7 +144,30 @@ module BackendExamples
         expect(results).to eq([cmd1, cmd2])
       end
 
-      it 'linearizes commands for the same stream'
+      it 'linearizes commands for the same stream' do
+        now = Time.now
+        cmd1 = Tests::DoSomething.parse(stream_id: 'ss1', created_at: now - 10, payload: { account_id: 1 })
+        cmd2 = Tests::DoSomething.parse(stream_id: 'ss1', created_at: now - 10, payload: { account_id: 1 })
+        cmd3 = Tests::DoSomething.parse(stream_id: 'ss2', created_at: now - 5, payload: { account_id: 1 })
+        backend.schedule_commands([cmd1, cmd2, cmd3])
+        results = Concurrent::Array.new
+
+        2.times.map do
+          Thread.new do
+            backend.next_command do |c|
+              sleep 0.01
+              results << c
+            end
+          end
+        end.map(&:join)
+
+        expect(results).to match_array([cmd1, cmd3])
+
+        backend.next_command do |c|
+          results << c
+        end
+        expect(results).to match_array([cmd1, cmd3, cmd2])
+      end
     end
 
     describe '#append_to_stream and #reserve_next_for_reactor' do


### PR DESCRIPTION
First stab at a command bus supporting commands scheduled to run at a future time.

Background workers poll for commands as well as events. A command that is processed successfully (by a single worker) is immediately deleted.

Commands produced by reactors are scheduled to be picked up by the next polling worker (or the same worker, on the next poll).

Workers lock command fetching by stream id, so that commands for the same stream are processed linearly regardless of worker.

To schedule commands:

```ruby
Sourced.config.backend.schedule_commands([cmd1, cmd2])
```

To process (and delete, if successful) the next command:

```ruby
backend.next_command do |cmd|
  # process cmd here
  # if this block raises an exception
  # the command won't be deleted and can be retried by the next worker poll
end
```

Reactors can return "delayed" commands that will be run in the future.

```ruby
react SomeEvent do |evt|
  evt.follow(SomeCommand).delay(Time.now + 3600)
end
```

## TODO

* Should failed commands be allowed to fail forever? Should they be moved to a dead letter queue and notified?
* Should commands be processed even if they've been in the command bus for a long time?
* Perhaps the latter is fine, and it's up to command handlers to decide whether to ignore old commands, or handle them differently.
* Handle exceptions on `Router#handle_command()` to avoid killing the workers.
