### PR TITLE
Sourced.register

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ cart2.state.items.size # 1
 Invoking commands directly on an actor instance works in an IRB console or a synchronous-only web handler, but for actors to be available to background workers, and to react to other actor's events, you need to register them.
 
 ```ruby
-Sourced::Router.register(Cart)
+Sourced.register(Cart)
 ```
 
 This achieves two things:
@@ -316,7 +316,7 @@ Like any other _reactor_, projectors need to be registered for background worker
 
 ```ruby
 # In your app's configuration
-Sourced::Router.register(CartListings)
+Sourced.register(CartListings)
 ```
 
 ## Concurrency model
@@ -432,9 +432,9 @@ Sourced.config.backend.install unless Sourced.config.backend.installed?
 Register your Actor's and Reactors.
 
 ```ruby
-Sourced::Router.register(Leads::Actor)
-Sourced::Router.register(Leads::Listings)
-Sourced::Router.register(Webooks::Dispatcher)
+Sourced.register(Leads::Actor)
+Sourced.register(Leads::Listings)
+Sourced.register(Webooks::Dispatcher)
 ```
 
 Start background workers.

--- a/examples/cart.rb
+++ b/examples/cart.rb
@@ -223,8 +223,8 @@ end
 
 # Register Reactor interfaces with the Router
 # This allows the Router to route commands and events to reactors
-Sourced::Router.register(LoggingReactor)
-Sourced::Router.register(Cart)
-Sourced::Router.register(Mailer)
-Sourced::Router.register(CartEmailsSaga)
-Sourced::Router.register(CartListings)
+Sourced.register(LoggingReactor)
+Sourced.register(Cart)
+Sourced.register(Mailer)
+Sourced.register(CartEmailsSaga)
+Sourced.register(CartListings)

--- a/lib/sourced.rb
+++ b/lib/sourced.rb
@@ -20,6 +20,10 @@ module Sourced
     config
   end
 
+  def self.register(reactor)
+    Router.register(reactor)
+  end
+
   def self.message_method_name(prefix, name)
     "__handle_#{prefix}_#{name.split('::').map(&:downcase).join('_')}"
   end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -81,7 +81,7 @@ module TestActor
     end
   end
 
-  Sourced::Router.register(TodoListActor)
+  Sourced.register(TodoListActor)
 
   class Listener
     def self.call(state, command, events); end
@@ -339,7 +339,7 @@ RSpec.describe Sourced::Actor do
 
     before do
       # Register so that sync! works
-      Sourced::Router.register(klass)
+      Sourced.register(klass)
     end
 
     it 'resolves own commands by Symbol' do
@@ -387,7 +387,7 @@ RSpec.describe Sourced::Actor do
 
     before do
       # Register so that sync! works
-      Sourced::Router.register(klass)
+      Sourced.register(klass)
     end
 
     it 'evolves and yields own state' do

--- a/spec/immediate_consistency_spec.rb
+++ b/spec/immediate_consistency_spec.rb
@@ -37,7 +37,7 @@ end
 RSpec.describe 'Immediate consistency' do
   before do
     Sourced.config.backend.clear!
-    Sourced::Router.register(SyncTodoListActor)
+    Sourced.register(SyncTodoListActor)
   end
 
   let(:cmd) { SyncTodoListActor[:add_item].parse(stream_id: 'list1', payload: { name: 'item1' }) }


### PR DESCRIPTION
Move from `Sourced::Router.register` to `Sourced.register`

Shorter and less exposing the machinery.