### PR TITLE
WIP: Pub Sub

### DIFF
--- a/lib/sourced/backends/sequel_pub_sub.rb
+++ b/lib/sourced/backends/sequel_pub_sub.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'sequel'
+require 'thread'
+require 'json'
+
+module Sourced
+  module Backends
+    class SequelPubSub
+      def initialize(db:)
+        @db = db
+      end
+
+      def subscribe(channel_name, handler = nil, &block)
+        Channel.new(db: @db, name: channel_name, handler: handler || block).start
+      end
+
+      def publish(channel_name, event)
+        event_data = JSON.dump(event.to_h)
+        @db.run(Sequel.lit('SELECT pg_notify(?, ?)', channel_name, event_data))
+        self
+      end
+    end
+
+    class Channel
+      NOTIFY_CHANNEL = 'sourced-scheduler-ch'
+
+      attr_reader :name
+
+      def initialize(db:, handler:, name: NOTIFY_CHANNEL)
+        @db = db
+        @name = name
+        @handler = handler
+        @running = false
+      end
+
+      def start
+        return self if @running
+
+        @running = true
+        @db.listen(@name, loop: true) do |_channel, _pid, payload|
+          @handler.call parse(payload)
+          break unless @running
+          # TODO: handle exceptions
+        end
+
+        self
+      end
+
+      # Public so that we can test this separately from async channel listening.
+      def parse(payload)
+        data = JSON.parse(payload, symbolize_names: true)
+        Sourced::Message.from(data)
+      end
+
+      def stop
+        @running = false
+      end
+    end
+  end
+end

--- a/lib/sourced/backends/sequel_pub_sub.rb
+++ b/lib/sourced/backends/sequel_pub_sub.rb
@@ -39,7 +39,7 @@ module Sourced
 
         @running = true
         @db.listen(@name, loop: true) do |_channel, _pid, payload|
-          @handler.call parse(payload)
+          @handler.call parse(payload), self
           break unless @running
           # TODO: handle exceptions
         end

--- a/lib/sourced/backends/test_backend.rb
+++ b/lib/sourced/backends/test_backend.rb
@@ -166,15 +166,21 @@ module Sourced
         end
       end
 
+      # An in-meory pubsub implementation for testing
       class TestPubSub
         def initialize
           @channels = {}
         end
 
+        # @param channel_name [String]
+        # @return [Channel]
         def subscribe(channel_name)
           @channels[channel_name] ||= Channel.new(channel_name)
         end
 
+        # @param channel_name [String]
+        # @param event [Sourced::Message]
+        # @return [self]
         def publish(channel_name, event)
           channel = @channels[channel_name]
           channel&.publish(event)

--- a/lib/sourced/backends/test_backend.rb
+++ b/lib/sourced/backends/test_backend.rb
@@ -171,11 +171,8 @@ module Sourced
           @channels = {}
         end
 
-        def subscribe(channel_name, handler = nil, &block)
-          handler ||= block
-          ch = @channels[channel_name] ||= Channel.new(channel_name)
-          ch.subscribe(handler)
-          ch.start
+        def subscribe(channel_name)
+          @channels[channel_name] ||= Channel.new(channel_name)
         end
 
         def publish(channel_name, event)
@@ -192,17 +189,19 @@ module Sourced
             @handlers = []
           end
 
-          def subscribe(handler)
+          def start(handler: nil, &block)
+            handler ||= block
             @handlers << handler
           end
 
           def publish(event)
             @handlers.each do |handler|
-              handler.call(event, self)
+              catch(:stop) do
+                handler.call(event, self)
+              end
             end
           end
 
-          def start = self
           def stop = nil
         end
       end

--- a/lib/sourced/backends/test_backend.rb
+++ b/lib/sourced/backends/test_backend.rb
@@ -84,6 +84,8 @@ module Sourced
         attr_reader :backend
       end
 
+      attr_reader :pubsub
+
       def initialize
         clear!
         @mutex = Mutex.new
@@ -164,8 +166,50 @@ module Sourced
         end
       end
 
+      class TestPubSub
+        def initialize
+          @channels = {}
+        end
+
+        def subscribe(channel_name, handler = nil, &block)
+          handler ||= block
+          ch = @channels[channel_name] ||= Channel.new(channel_name)
+          ch.subscribe(handler)
+          ch.start
+        end
+
+        def publish(channel_name, event)
+          channel = @channels[channel_name]
+          channel&.publish(event)
+          self
+        end
+
+        class Channel
+          attr_reader :name
+
+          def initialize(name)
+            @name = name
+            @handlers = []
+          end
+
+          def subscribe(handler)
+            @handlers << handler
+          end
+
+          def publish(event)
+            @handlers.each do |handler|
+              handler.call(event, self)
+            end
+          end
+
+          def start = self
+          def stop = nil
+        end
+      end
+
       def clear!
         @state = State.new
+        @pubsub = TestPubSub.new
       end
 
       def installed? = true

--- a/lib/sourced/projector.rb
+++ b/lib/sourced/projector.rb
@@ -43,7 +43,7 @@ module Sourced
 
     def handle_events(events)
       evolve(state, events)
-      save
+      save(state, events)
       [] # no commands
     end
 
@@ -55,9 +55,9 @@ module Sourced
       nil
     end
 
-    def save
+    def save(state, events)
       backend.transaction do
-        run_sync_blocks(state, nil, [])
+        run_sync_blocks(state, nil, events)
       end
     end
 

--- a/spec/projector_spec.rb
+++ b/spec/projector_spec.rb
@@ -34,8 +34,8 @@ module ProjectorTest
       state.total += event.payload.amount
     end
 
-    sync do |state, _, _events|
-      STORE[state.id] = state
+    sync do |state, _, events|
+      STORE[state.id] = [state, events.last.type]
     end
   end
 end
@@ -83,7 +83,9 @@ RSpec.describe Sourced::Projector do
       result = ProjectorTest::EventSourced.handle_events([e1, e2])
 
       expect(result).to eq([])
-      expect(ProjectorTest::STORE['111'].total).to eq(15)
+      obj, last_event_type = ProjectorTest::STORE['111']
+      expect(obj.total).to eq(15)
+      expect(last_event_type).to eq('prtest.added')
     end
 
     specify 'with previous events' do
@@ -96,7 +98,9 @@ RSpec.describe Sourced::Projector do
       result = ProjectorTest::EventSourced.handle_events([e2, e3])
 
       expect(result).to eq([])
-      expect(ProjectorTest::STORE['111'].total).to eq(22)
+      obj, last_event_type = ProjectorTest::STORE['111']
+      expect(obj.total).to eq(22)
+      expect(last_event_type).to eq('prtest.added')
     end
   end
 end

--- a/spec/shared_examples/backend_examples.rb
+++ b/spec/shared_examples/backend_examples.rb
@@ -452,9 +452,9 @@ module BackendExamples
         received = []
         Sync do |task|
           task.async do
-            backend.pubsub.subscribe('test_channel') do |event|
+            backend.pubsub.subscribe('test_channel') do |event, channel|
               received << event
-              break if received.size == 2
+              channel.stop if received.size == 2
             end
           end
           task.async do
@@ -463,7 +463,7 @@ module BackendExamples
             backend.pubsub.publish('test_channel', e1)
             backend.pubsub.publish('test_channel', e2)
           end
-        end
+        end.wait
 
         expect(received.map(&:type)).to eq(%w[tests.something_happened1 tests.something_happened1])
         expect(received.map(&:seq)).to eq([1, 2])

--- a/spec/shared_examples/backend_examples.rb
+++ b/spec/shared_examples/backend_examples.rb
@@ -449,12 +449,14 @@ module BackendExamples
 
     describe '#pubsub' do
       it 'publishes and subscribes to events' do
+        channel1 = backend.pubsub.subscribe('test_channel')
         received = []
+
         Sync do |task|
           task.async do
-            backend.pubsub.subscribe('test_channel') do |event, channel|
+            channel1.start do |event, _channel|
               received << event
-              channel.stop if received.size == 2
+              throw :stop if received.size == 2
             end
           end
           task.async do


### PR DESCRIPTION
Backends include a `#pubsub` interface to publish and subscribe to ephemeral events.

Actors and reactors can publish their events after processing, so that the UI and other ephemeral consumers can act on it.

Example: an Actor can publish an event on a channel name scoped by event metadata.

```ruby
class HolidayBooking < Sourced::Actor
  # events, commands, reactions, etc

  # This blocks runs in the same transaction as persisting new events
  # Here we publish the last event to a channel named after the tenant_id
  # included in event metadata for this app
  # In future I might provide a DSL for this
  sync do |state, cmd, events|
    channel_name = events.last.metadata[:tenant_id].to_s
    Sourced.config.backend.pubsub.publish(channel_name, events.last)
  end
end
```

Now, a UI connection (example on a websocket or SSE stream) can subscribe to this channel and push updates to the browser.

```ruby
# GET /updates
channel_name = session[:tenant_id]
channel = Sourced.config.backend.pubsub.subscribe(channel_name)

channel.start do |evt, ch|
  case evt
    when HolidayBooking::HotelBooked
      push_ui_template Components::HolidayPage.new(...)
    when HolidayListings::Updated
      push_ui_template Components::HolidayListings.new(...)
  end
end
```

### Implementations

This PR includes two implementations of this interface:

* An in-memory version for the default Test Backend.
* One for the built-in Sequel/Postgres backend using Postgres' `LISTEN./ NOTIFY`. Note that this might pretty quickly hit connection pool limits.

I'll experiment with this feature a bit more. Potentially there could be Redis or Nats adapter for higher throughput and concurrency.

https://github.com/user-attachments/assets/5906a193-7326-4496-892c-aaef599afe38


