### PR TITLE
Exception handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,15 +5,15 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in sourced.gemspec
 gemspec
 
-gem 'rake', '~> 13.0'
-
 gem 'debug'
-gem 'rspec', '~> 3.0'
+gem 'rake', '~> 13.0'
+gem 'rubocop'
 
 group :test do
   gem 'activerecord', require: false
   gem 'dotenv'
   gem 'pg'
+  gem 'rspec', '~> 3.0'
   gem 'sequel'
   gem 'sqlite3'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+    ast (2.4.2)
     async (2.17.0)
       console (~> 1.26)
       fiber-annotation
@@ -55,18 +56,27 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.7.2)
+    language_server-protocol (3.17.0.4)
+    lint_roller (1.1.0)
     logger (1.6.1)
     mini_portile2 (2.8.7)
     minitest (5.25.1)
+    parallel (1.26.3)
+    parser (3.3.7.1)
+      ast (~> 2.4.1)
+      racc
     pg (1.5.8)
     plumb (0.0.11)
       bigdecimal
       concurrent-ruby
     psych (5.1.2)
       stringio
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.2.1)
     rdoc (6.7.0)
       psych (>= 4.0.0)
+    regexp_parser (2.10.0)
     reline (0.5.10)
       io-console (~> 0.5)
     rspec (3.13.0)
@@ -82,6 +92,20 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
+    rubocop (1.72.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.38.0)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
     securerandom (0.3.1)
     sequel (5.84.0)
       bigdecimal
@@ -93,6 +117,9 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
   arm64-darwin-23
@@ -105,6 +132,7 @@ DEPENDENCIES
   pg
   rake (~> 13.0)
   rspec (~> 3.0)
+  rubocop
   sequel
   sourced!
   sqlite3

--- a/examples/cart.rb
+++ b/examples/cart.rb
@@ -110,7 +110,7 @@ end
 class CartEmailsSaga < Sourced::Actor
   # Listen for Cart::Placed events and
   # send command to Mailer
-  react Cart::Placed do |event|
+  reaction Cart::Placed do |event|
     event.follow_with_stream_id(
       Mailer::SendEmail,
       "mailer-#{event.stream_id}",
@@ -120,7 +120,7 @@ class CartEmailsSaga < Sourced::Actor
 
   # Listen for Mailer::EmailSent events and
   # send command to Cart
-  react Mailer::EmailSent do |event|
+  reaction Mailer::EmailSent do |event|
     event.follow_with_stream_id(
       Cart::Notify,
       event.payload.cart_id,

--- a/examples/cart.rb
+++ b/examples/cart.rb
@@ -60,6 +60,15 @@ class Cart < Sourced::Actor
     event(Notified, mailer_id: cmd.payload.mailer_id)
   end
 
+  def self.on_exception(exception, _message, group)
+    if group.error_context[:retry_count] < 3
+      later = 5 + 5 * group.error_context[:retry_count]
+      group.retry(later)
+    else
+      group.stop(exception)
+    end
+  end
+
   event ItemAdded do |cart, event|
     cart.items << event.payload
   end

--- a/lib/sourced.rb
+++ b/lib/sourced.rb
@@ -24,6 +24,10 @@ module Sourced
     Router.register(reactor)
   end
 
+  def self.schedule_commands(commands)
+    Router.schedule_commands(commands)
+  end
+
   def self.message_method_name(prefix, name)
     "__handle_#{prefix}_#{name.split('::').map(&:downcase).join('_')}"
   end

--- a/lib/sourced.rb
+++ b/lib/sourced.rb
@@ -32,8 +32,8 @@ module Sourced
     "__handle_#{prefix}_#{name.split('::').map(&:downcase).join('_')}"
   end
 
-  DeciderInterface = Types::Interface[:handled_commands, :handle_command]
-  ReactorInterface = Types::Interface[:consumer_info, :handled_events, :handle_events]
+  DeciderInterface = Types::Interface[:handled_commands, :handle_command, :on_exception]
+  ReactorInterface = Types::Interface[:consumer_info, :handled_events, :handle_events, :on_exception]
 end
 
 require 'sourced/consumer'

--- a/lib/sourced/actor.rb
+++ b/lib/sourced/actor.rb
@@ -263,14 +263,14 @@ module Sourced
         define_method("#{cmd_name}_async") do |**payload|
           cmd = cmd_class.new(stream_id: id, payload:)
           cmd.tap do |c|
-            Sourced.config.backend.schedule_commands([c]) if c.valid?
+            Sourced.schedule_commands([c]) if c.valid?
           end
         end
 
         define_method("#{cmd_name}_later") do |time, **payload|
           cmd = cmd_class.new(stream_id: id, payload:).delay(time)
           cmd.tap do |c|
-            Sourced.config.backend.schedule_commands([c]) if c.valid?
+            Sourced.schedule_commands([c]) if c.valid?
           end
         end
       end

--- a/lib/sourced/backends/sequel_backend.rb
+++ b/lib/sourced/backends/sequel_backend.rb
@@ -178,11 +178,11 @@ module Sourced
           @updates[:error_context][:reason] = reason if reason
         end
 
-        def retry(time)
+        def retry(time, ctx = {})
           @logger.warn "retrying consumer group #{group_id} at #{time}"
           @updates[:updated_at] = Time.now
           @updates[:retry_at] = time
-          @updates[:error_context][:retry_count] += 1
+          @updates[:error_context].merge!(ctx)
         end
       end
 
@@ -203,7 +203,6 @@ module Sourced
         raise ArgumentError, "Consumer group #{group_id} not found" unless group_row
 
         ctx = group_row[:error_context] ? parse_json(group_row[:error_context]) : {}
-        ctx[:retry_count] ||= 0
         group_row[:error_context] = ctx
         group = GroupUpdater.new(group_id, group_row, logger)
         yield group

--- a/lib/sourced/backends/test_backend.rb
+++ b/lib/sourced/backends/test_backend.rb
@@ -110,8 +110,8 @@ module Sourced
           end
 
           if evt
-            if block_given?
-              yield(evt)
+            if block_given? && yield(evt)
+              # ACK reactor/event if block returns truthy
               offset.index = index
             end
             offset.locked = false

--- a/lib/sourced/backends/test_backend.rb
+++ b/lib/sourced/backends/test_backend.rb
@@ -34,9 +34,8 @@ module Sourced
           @status = :stopped
         end
 
-        def retry(time)
-          @error_context[:retry_count] ||= 0
-          @error_context[:retry_count] += 1
+        def retry(time, ctx = {})
+          @error_context.merge!(ctx)
           @retry_at = time
         end
 
@@ -289,7 +288,6 @@ module Sourced
       def updating_consumer_group(group_id, &)
         transaction do
           group = @state.groups[group_id]
-          group.error_context[:retry_count] ||= 0
           yield group
         end
       end

--- a/lib/sourced/backends/test_backend.rb
+++ b/lib/sourced/backends/test_backend.rb
@@ -267,7 +267,9 @@ module Sourced
         start_from = reactor.consumer_info.start_from.call
         transaction do
           group = @state.groups[group_id]
-          group.reserve_next(reactor.handled_events, start_from, &) if group.active?
+          if group.active? && (group.retry_at.nil? || group.retry_at <= Time.now)
+            group.reserve_next(reactor.handled_events, start_from, &)
+          end
         end
       end
 

--- a/lib/sourced/configuration.rb
+++ b/lib/sourced/configuration.rb
@@ -3,6 +3,7 @@
 require 'console' #  comes with async gem
 require 'sourced/types'
 require 'sourced/backends/test_backend'
+require 'sourced/error_strategy'
 
 module Sourced
   # Configure a Sourced app.
@@ -27,11 +28,12 @@ module Sourced
     ]
 
     attr_accessor :logger
-    attr_reader :backend
+    attr_reader :backend, :error_strategy
 
     def initialize
       @logger = Console
       @backend = Backends::TestBackend.new
+      @error_strategy = ErrorStrategy.new
     end
 
     # Configure the backend for the app.

--- a/lib/sourced/consumer.rb
+++ b/lib/sourced/consumer.rb
@@ -65,9 +65,10 @@ module Sourced
     # @example retry with exponential back off
     #
     #   def self.on_exception(exception, _message, group)
-    #     if group.error_context[:retry_count] < 3
-    #       later = 5 + 5 * group.error_context[:retry_count]
-    #       group.retry(later)
+    #     retry_count = group.error_context[:retry_count] || 0
+    #     if retry_count < 3
+    #       later = 5 + 5 * retry_count
+    #       group.retry(later, retry_count: retry_count + 1)
     #     else
     #       group.stop(exception)
     #     end

--- a/lib/sourced/consumer.rb
+++ b/lib/sourced/consumer.rb
@@ -77,7 +77,7 @@ module Sourced
     # @param message [Sourced::Message] the event or command being handled
     # @param group [#stop, #retry] consumer group object to update state, ie. for retries
     def on_exception(exception, message, group)
-      group.stop(exception)
+      group.stop(exception:, message:)
     end
   end
 end

--- a/lib/sourced/consumer.rb
+++ b/lib/sourced/consumer.rb
@@ -59,5 +59,25 @@ module Sourced
 
       @consumer_info = info
     end
+
+    # Implement this in your reactors
+    # to manage exception handling in eventually-consistent workflows
+    # @example retry with exponential back off
+    #
+    #   def self.on_exception(exception, _message, group)
+    #     if group.error_context[:retry_count] < 3
+    #       later = 5 + 5 * group.error_context[:retry_count]
+    #       group.retry(later)
+    #     else
+    #       group.stop(exception)
+    #     end
+    #   end
+    #
+    # @param exception [Exception] the exception raised
+    # @param message [Sourced::Message] the event or command being handled
+    # @param group [#stop, #retry] consumer group object to update state, ie. for retries
+    def on_exception(exception, _message, group)
+      group.stop(exception)
+    end
   end
 end

--- a/lib/sourced/consumer.rb
+++ b/lib/sourced/consumer.rb
@@ -76,7 +76,7 @@ module Sourced
     # @param exception [Exception] the exception raised
     # @param message [Sourced::Message] the event or command being handled
     # @param group [#stop, #retry] consumer group object to update state, ie. for retries
-    def on_exception(exception, _message, group)
+    def on_exception(exception, message, group)
       group.stop(exception)
     end
   end

--- a/lib/sourced/consumer.rb
+++ b/lib/sourced/consumer.rb
@@ -78,7 +78,7 @@ module Sourced
     # @param message [Sourced::Message] the event or command being handled
     # @param group [#stop, #retry] consumer group object to update state, ie. for retries
     def on_exception(exception, message, group)
-      group.stop(exception:, message:)
+      Sourced.config.error_strategy.call(exception, message, group)
     end
   end
 end

--- a/lib/sourced/error_strategy.rb
+++ b/lib/sourced/error_strategy.rb
@@ -2,11 +2,56 @@
 
 module Sourced
   class ErrorStrategy
+    MAX_RETRIES = 0
+    RETRY_AFTER = 3 # seconds
+    BACKOFF = ->(retry_after, retry_count) { retry_after * retry_count }
+    NOOP_CALLBACK = ->(*_) {}
+
+    def initialize(&setup)
+      @max_retries = MAX_RETRIES
+      @retry_after = RETRY_AFTER
+      @backoff = BACKOFF
+      @on_retry = NOOP_CALLBACK
+      @on_stop = NOOP_CALLBACK
+
+      yield(self) if block_given?
+      freeze
+    end
+
+    def retry(times: nil, after: nil, backoff: nil)
+      @max_retries = times if times
+      @retry_after = after if after
+      @backoff = backoff if backoff
+      self
+    end
+
+    def on_retry(callable = nil, &blk)
+      @on_retry = callable || blk
+    end
+
+    def on_stop(callable = nil, &blk)
+      @on_stop = callable || blk
+    end
+
     # @param exception [Exception]
     # @param message [Sourced::Message]
     # @param group [#retry, #stop]
     def call(exception, message, group)
-      group.stop(exception:, message:)
+      retry_count = group.error_context[:retry_count] || 1
+      if retry_count <= max_retries
+        now = Time.now.utc
+        later = now + (backoff.call(retry_after, retry_count))
+        @on_retry.call(retry_count, exception, message, later)
+        retry_count += 1
+        group.retry(later, retry_count:)
+      else
+        @on_stop.call(exception, message)
+        group.stop(exception:, message:)
+      end
     end
+
+    private
+
+    attr_reader :max_retries, :retry_after, :backoff
   end
 end

--- a/lib/sourced/error_strategy.rb
+++ b/lib/sourced/error_strategy.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Sourced
+  class ErrorStrategy
+    # @param exception [Exception]
+    # @param message [Sourced::Message]
+    # @param group [#retry, #stop]
+    def call(exception, message, group)
+      group.stop(exception:, message:)
+    end
+  end
+end

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -73,7 +73,11 @@ module Sourced
         end
       end
 
-      raise InvalidReactorError, "#{thing.inspect} is not a valid Decider or Reactor interface" unless regs.positive?
+      if regs.positive?
+        backend.register_consumer_group(thing.consumer_info.group_id)
+      else
+        raise InvalidReactorError, "#{thing.inspect} is not a valid Decider or Reactor interface"
+      end
     end
 
     # Schedule commands for later processing

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -158,8 +158,8 @@ module Sourced
         # but we also DO NOT WANT TO ACK THIS COMMAND
         # Ie it should not be removed from the command bus
         # Same for #handle_next_event_for_reactor() below
-        backend.updating_consumer_group(reactor.consumer_info.group_id) do |ctx|
-          reactor.on_exception(e, cmd, ctx)
+        backend.updating_consumer_group(reactor.consumer_info.group_id) do |group|
+          reactor.on_exception(e, cmd, group)
         end
         # Do not remove command
         false

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -94,6 +94,7 @@ module Sourced
     def handle_next_event_for_reactor(reactor, process_name = nil)
       backend.reserve_next_for_reactor(reactor) do |event|
         log_event('handling event', reactor, event, process_name)
+        #  TODO: handle exceptions here
         commands = reactor.handle_events([event])
         if commands.any?
           # TODO: handle decider errors
@@ -127,7 +128,7 @@ module Sourced
 
     def dispatch_next_command
       backend.next_command do |cmd|
-        #  TODO: error handling
+        #  TODO: handle exceptions here
         handle_command(cmd)
       end
     end

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -170,6 +170,13 @@ module Sourced
         end
 
         event
+      rescue StandardError => e
+        logger.warn "[#{PID}]: error handling event #{event.class} with reactor #{reactor} #{e}"
+        backend.updating_consumer_group(reactor.consumer_info.group_id) do |group|
+          reactor.on_exception(e, event, group)
+        end
+        # Do not ACK event for reactor
+        false
       end
     end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -13,6 +13,24 @@ RSpec.describe Sourced::Configuration do
     expect(config.error_strategy).to be_a(Sourced::ErrorStrategy)
   end
 
+  specify '#error_strategy=' do
+    st = Sourced::ErrorStrategy.new
+    config.error_strategy = st
+    expect(config.error_strategy).to eq(st)
+  end
+
+  describe '#error_strategy(&block)' do
+    it 'configures the error strategy with a block' do
+      config.error_strategy do |s|
+        s.retry(times: 30, after: 50)
+      end
+
+      expect(config.error_strategy).to be_a(Sourced::ErrorStrategy)
+      expect(config.error_strategy.max_retries).to eq(30)
+      expect(config.error_strategy.retry_after).to eq(50)
+    end
+  end
+
   describe '#backend=' do
     it 'can configure backend with a Sequel database' do
       config.backend = Sequel.sqlite

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Sourced::Configuration do
     expect(config.backend).to be_a(Sourced::Backends::TestBackend)
   end
 
+  it 'has a default #error_strategy' do
+    expect(config.error_strategy).to be_a(Sourced::ErrorStrategy)
+  end
+
   describe '#backend=' do
     it 'can configure backend with a Sequel database' do
       config.backend = Sequel.sqlite

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -80,4 +80,13 @@ RSpec.describe Sourced::Consumer do
       expect(klass.consumer_info.async).to be(false)
     end
   end
+
+  describe '.on_exception' do
+    it 'stops the consumer group by default' do
+      group = double('group', error_context: { retry_count: 3 }, stop: true)
+      exception = StandardError.new('test error')
+      TestConsumer::TestConsumer.on_exception(exception, nil, group)
+      expect(group).to have_received(:stop).with(exception)
+    end
+  end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Sourced::Consumer do
 
   describe '.on_exception' do
     it 'stops the consumer group by default' do
-      group = double('group', error_context: { retry_count: 3 }, stop: true)
+      group = double('group', error_context: {}, stop: true)
       exception = StandardError.new('test error')
       message = { id: 1 }
       TestConsumer::TestConsumer.on_exception(exception, message, group)

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -85,8 +85,9 @@ RSpec.describe Sourced::Consumer do
     it 'stops the consumer group by default' do
       group = double('group', error_context: { retry_count: 3 }, stop: true)
       exception = StandardError.new('test error')
-      TestConsumer::TestConsumer.on_exception(exception, nil, group)
-      expect(group).to have_received(:stop).with(exception)
+      message = { id: 1 }
+      TestConsumer::TestConsumer.on_exception(exception, message, group)
+      expect(group).to have_received(:stop).with(exception:, message:)
     end
   end
 end

--- a/spec/error_strategy_spec.rb
+++ b/spec/error_strategy_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Sourced::ErrorStrategy do
+  let(:group_class) do
+    Struct.new(:status, :retry_at, :error_context) do
+      def retry(later, ctx = {})
+        self.retry_at = later
+        self.error_context.merge!(ctx)
+        self
+      end
+
+      def stop(reason = {})
+        self.status = :stopped
+        self.error_context.merge!(reason:)
+        self
+      end
+    end
+  end
+  let(:group) { group_class.new(:active, nil, {}) }
+  let(:exception) { StandardError.new }
+  let(:message) { Sourced::Message.new }
+
+  before do
+    allow(group).to receive(:retry).and_call_original
+    allow(group).to receive(:stop).and_call_original
+  end
+
+  it 'stops the group immediatly by default' do
+    strategy = described_class.new
+    strategy.call(exception, message, group)
+    expect(group).to have_received(:stop).with(exception:, message:)
+  end
+
+  it 'can be configured with retries' do
+    now = Time.new(2020, 1, 1).utc
+
+    retries = []
+    stop_call = nil
+
+    strategy = described_class.new do |s|
+      s.retry(times: 3, after: 5, backoff: ->(retry_after, retry_count) { retry_after * retry_count })
+
+      s.on_retry do |n, exception, message, later|
+        retries << [n, exception, message, later]
+      end
+
+      s.on_stop do |exception, message|
+        stop_call = [exception, message]
+      end
+    end
+
+    Timecop.freeze(now) do
+      strategy.call(exception, message, group)
+      strategy.call(exception, message, group)
+      strategy.call(exception, message, group)
+
+      expect(stop_call).to be(nil)
+
+      strategy.call(exception, message, group)
+
+      expect(retries).to eq([
+        [1, exception, message, now + 5],
+        [2, exception, message, now + 10],
+        [3, exception, message, now + 15]
+      ])
+
+      expect(stop_call).to eq([exception, message])
+
+      expect(group).to have_received(:retry).with(now + 5, retry_count: 2).exactly(1).times
+      expect(group).to have_received(:retry).with(now + 10, retry_count: 3).exactly(1).times
+      expect(group).to have_received(:retry).with(now + 15, retry_count: 4).exactly(1).times
+      expect(group).to have_received(:stop).exactly(1).times
+    end
+  end
+end

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -77,7 +77,34 @@ module RouterTest
 end
 
 RSpec.describe Sourced::Router do
-  subject(:router) { described_class.new }
+  subject(:router) { described_class.new(backend:) }
+
+  let(:backend) { Sourced::Backends::TestBackend.new }
+
+  # describe '#dispatch_next_command' do
+  #   before do
+  #     router.register(RouterTest::DeciderReactor)
+  #   end
+  #
+  #   context 'when reactor raises exception' do
+  #     it 'invokes .on_exception on reactor' do
+  #       cmd = RouterTest::AddItem.new
+  #       router.backend.schedule_commands([cmd])
+  #       expect(RouterTest::DeciderReactor).to receive(:handle_command).and_raise('boom')
+  #
+  #       router.dispatch_next_command
+  #     end
+  #   end
+  # end
+
+  describe '#schedule_commands' do
+    it 'schedules commands for the right target deciders' do
+      router.register(RouterTest::DeciderReactor)
+      cmd = RouterTest::AddItem.new
+      expect(backend).to receive(:schedule_commands).with([cmd], group_id: RouterTest::DeciderReactor.consumer_info.group_id)
+      router.schedule_commands([cmd])
+    end
+  end
 
   describe '#register' do
     it 'registers Decider interfaces' do

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -97,6 +97,13 @@ RSpec.describe Sourced::Router do
   #   end
   # end
 
+  describe '#register' do
+    it 'registers group id with configured backend' do
+      expect(backend).to receive(:register_consumer_group).with(RouterTest::DeciderReactor.consumer_info.group_id)
+      router.register(RouterTest::DeciderReactor)
+    end
+  end
+
   describe '#schedule_commands' do
     it 'schedules commands for the right target deciders' do
       router.register(RouterTest::DeciderReactor)

--- a/spec/shared_examples/backend_examples.rb
+++ b/spec/shared_examples/backend_examples.rb
@@ -578,7 +578,7 @@ module BackendExamples
         backend.register_consumer_group('group1')
         backend.updating_consumer_group('group1') do |group|
           counts << group.error_context[:retry_count]
-          group.retry(later)
+          group.retry(later, retry_count: 1)
         end
         backend.updating_consumer_group('group1') do |group|
           counts << group.error_context[:retry_count]
@@ -588,7 +588,7 @@ module BackendExamples
         expect(gr[:group_id]).to eq('group1')
         expect(gr[:status]).to eq('active')
         expect(gr[:retry_at]).to eq(later)
-        expect(counts).to eq([0, 1])
+        expect(counts).to eq([nil, 1])
       end
 
       specify '#stop(error)' do

--- a/spec/shared_examples/backend_examples.rb
+++ b/spec/shared_examples/backend_examples.rb
@@ -394,6 +394,48 @@ module BackendExamples
       end
     end
 
+    describe '#reserve_next_for_reactor with retry_at' do
+      it 'does not fetch events until retry_at is up' do
+        now = Time.now
+
+        evt_a1 = Tests::SomethingHappened1.parse(stream_id: 's1', seq: 1, payload: { account_id: 1 })
+        backend.append_to_stream('s1', [evt_a1])
+
+        reactor1 = Class.new do
+          def self.consumer_info
+            Sourced::Consumer::ConsumerInfo.new(group_id: 'group1')
+          end
+
+          def self.handled_events
+            [Tests::SomethingHappened1]
+          end
+        end
+
+        backend.register_consumer_group('group1')
+        backend.updating_consumer_group('group1') do |gr|
+          gr.retry(now + 4)
+        end
+
+        messages = []
+
+        backend.reserve_next_for_reactor(reactor1) do |msg|
+          messages << msg
+        end
+
+        expect(messages.any?).to be(false)
+
+        backend.updating_consumer_group('group1') do |gr|
+          gr.retry(now - 1)
+        end
+
+        backend.reserve_next_for_reactor(reactor1) do |msg|
+          messages << msg
+        end
+
+        expect(messages.any?).to be(true)
+      end
+    end
+
     describe '#ack_on' do
       let(:reactor) do
         Class.new do

--- a/spec/shared_examples/backend_examples.rb
+++ b/spec/shared_examples/backend_examples.rb
@@ -213,9 +213,12 @@ module BackendExamples
       it 'schedules messages and reserves them in order of arrival' do
         cmd_a = Tests::DoSomething.parse(stream_id: 's1', seq: 1, payload: { account_id: 1 })
         cmd_b = Tests::DoSomething.parse(stream_id: 's2', seq: 1, payload: { account_id: 2 })
-        evt_a1 = cmd_a.follow_with_seq(Tests::SomethingHappened1, 2, account_id: cmd_a.payload.account_id)
-        evt_a2 = cmd_a.follow_with_seq(Tests::SomethingHappened1, 3, account_id: cmd_a.payload.account_id)
-        evt_b1 = cmd_b.follow_with_seq(Tests::SomethingHappened1, 2, account_id: cmd_b.payload.account_id)
+        evt_a1 = cmd_a.with(metadata: { tid: 'evt_a1' }).follow_with_seq(Tests::SomethingHappened1, 2,
+                                                                         account_id: cmd_a.payload.account_id)
+        evt_a2 = cmd_a.with(metadata: { tid: 'evt_a2' }).follow_with_seq(Tests::SomethingHappened1, 3,
+                                                                         account_id: cmd_a.payload.account_id)
+        evt_b1 = cmd_b.with(metadata: { tid: 'evt_b1' }).follow_with_seq(Tests::SomethingHappened1, 2,
+                                                                         account_id: cmd_b.payload.account_id)
 
         reactor1 = Class.new do
           def self.consumer_info


### PR DESCRIPTION
### Error handling

* [ ] Better logging (include message type and ID?)

https://github.com/user-attachments/assets/311a0322-1537-4792-ae06-ae8df28daf4c


Sourced workflows are eventually-consistent by default. This means that commands and events are handled in background processes, and any exceptions raised can't be immediatly surfaced back to the user (and, there might not be a user anyway!).

Most "domain errors" in command handlers should be handled by the developer and recorded as domain events, so that the domain can react and/or compensate for them.

To handle true _exceptions_ (code or data bugs, network or IO exceptions) Sourced provides a default error strategy that will "stop" the affected consumer group (the Postgres backend will log the exception and offending message in the `consumer_groups` table).

You can configure the error strategy with retries and exponential backoff, as well as `on_retry` and `on_stop` callbacks.

```ruby
Sourced.configure do |config|
  # config.backend = Sequel.connect(ENV.fetch('DATABASE_URL'))
  config.error_strategy do |s|
    s.retry(
      # Retry up to 3 times
      times: 3,
      # Wait 5 seconds before retrying
      after: 5, 
      # Custom backoff: given after=5, retries in 5, 10 and 15 seconds before stopping
      backoff: ->(retry_after, retry_count) { retry_after * retry_count }
    )
    
    # Trigger this callback on each retry
    s.on_retry do |n, exception, message, later|
      LOGGER.info("Retrying #{n} times")
    end

    # Finally, trigger this callback
    # after all retries have failed and the consumer group is stopped.
    s.on_stop do |exception, message|
      Sentry.capture_exception(exception)
    end
  end
end
```

#### Custom error strategy

You can also configure your own error strategy. It must respond to `#call(exception, message, group)`

```ruby
CUSTOM_STRATEGY = proc do |exception, message, group|
  case exception
  when Faraday::Error
    group.retry(Time.now + 10)
  else
    group.stop(exception)
  end
end

Sourced.configure do |config|
  # Configure backend, etc
  config.error_strategy = CUSTOM_STRATEGY
end
```

#### Per-actor error handling

The `.on_exception` callback can be overridden on specific actor classes.

```ruby
class ShoppingCarts < Sourced::Actor
  def self.on_exception(exception, message, group)
    group.stop(exception)
  end
end
```

### Stopping and starting consumer groups programmatically.

`Sourced.config.backend` provides an API for stopping and starting consumer groups. For example to resume groups that were stopped by raised exceptions, after the error has been corrected.

```ruby
Sourced.config.backend.stop_consumer_group('Carts::Listings')
Sourced.config.backend.start_consumer_group('Carts::Listings')
```

### Notes

This PR changes the DB schema for the Postgres backend, introducing a `consumer_groups` table to keep track of consumer group state (`active` / `stopped`, `error_context` and `retry_at`)

