### PR TITLE
Backend#reset_consumer_group

### DIFF
--- a/lib/sourced/backends/sequel_backend.rb
+++ b/lib/sourced/backends/sequel_backend.rb
@@ -230,6 +230,23 @@ module Sourced
         end
       end
 
+      # Reset offsets for all streams tracked by a consumer group.
+      # If the consumer group is active, this will make it re-process all events
+      #
+      # @param group_id [String]
+      # @return [Boolean]
+      def reset_consumer_group(group_id)
+        db.transaction do
+          row = db[consumer_groups_table].where(group_id:).select(:id).first
+          return unless row
+
+          id = row[:id]
+          db[offsets_table].where(group_id: id).delete
+        end
+
+        true
+      end
+
       def ack_on(group_id, event_id, &)
         db.transaction do
           row = db.fetch(sql_for_ack_on, group_id, event_id).first


### PR DESCRIPTION
Add a `Backend#reset_consumer_group(group_id)` method to reset all stream offsets for a consumer group, so that the group starts processing events for all streams, from the beginning again.

Use case: rebuilding projections.


https://github.com/user-attachments/assets/d28491d2-3c66-4e20-9864-eeb635627801

