### PR TITLE
Replaying flag and projection reactions with state

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,11 @@ class ReadyOrders < Sourced::Projector::StateStored
 end
 ```
 
+##### Skipping projector reactions when replaying events
 
+When a projector's offsets are reset (so that it starts re-processing events and re- building projections), Sourced skips invoking a projector's `.reaction` handlers. This is because building projections should be deterministic, and rebuilding them should not trigger side-effects such as automation (we don't want to call 3rd party APIs, send emails, or just dispatch the same commands over and over when rebuilding projections).
+
+To do this, Sourced keeps track of each consumer groups' highest acknowledged event sequence. When a consumer group is reset and starts re-processing past events, this sequence number is compared with each event's sequence, which tells us whether the event has been processed before.
 
 ## Concurrency model
 

--- a/README.md
+++ b/README.md
@@ -234,11 +234,11 @@ stream_for(Sourced.new_stream_id).command CheckInventory, event.payload
 stream_for(NotifierActor).command :notify, message: 'hello!'
 ```
 
-#### `.reaction_with_state` block
+##### `.reaction` block with actor state
 
-Class-level `.react_with_state` is similar to `.react`, except that it also loads and yields the Actor's current state by loading and applying past events to it (same as when handling commands).
+If the block to `.reaction`  defines two arguments, this will cause Sourced to load up and yield the Actor's current state by loading and applying past events to it (same as when handling commands).
 
-For this reason, `.react_with_state` can only be used with events that are also registered to _evolve_ the same Actor.
+For this reason,  in this mode `.reaction` can only be used with events that are also registered to _evolve_ the same Actor.
 
 ![react](docs/images/sourced-react-with-state-handler.png)
 
@@ -249,7 +249,20 @@ event ItemAdded do |state, event|
 end
 
 # Now react to it and check state
-reaction_with_state ItemAdded do |state, event|
+reaction ItemAdded do |state, event|
+  if state[:item_count] > 30
+    stream_for(event).command NotifyBigCart
+  end
+end
+```
+
+##### `.reaction` with state for all events
+
+If the event name or class is omitted, the `.reaction` macro registers reaction handlers for all events already registered for the actor with the `.event` macro, minus events that have specific reaction handlers defined.
+
+```ruby
+# wildcard reaction for all evolved events
+reaction do |state, event|
   if state[:item_count] > 30
     stream_for(event).command NotifyBigCart
   end

--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ class ReadyOrders < Sourced::Projector::StateStored
 end
 ```
 
+Projectors can also define `.reaction event_class do |state, event|` to react to specific events.
+
 ##### Skipping projector reactions when replaying events
 
 When a projector's offsets are reset (so that it starts re-processing events and re- building projections), Sourced skips invoking a projector's `.reaction` handlers. This is because building projections should be deterministic, and rebuilding them should not trigger side-effects such as automation (we don't want to call 3rd party APIs, send emails, or just dispatch the same commands over and over when rebuilding projections).

--- a/README.md
+++ b/README.md
@@ -354,6 +354,9 @@ Sourced projectors can define `.reaction` handlers that will be called after evo
 
 This can be useful to implement TODO List patterns where a projector persists projected data, and then reacts to the data update using the data to schedule the next command in a workflow.
 
+![CleanShot 2025-05-30 at 18 43 01](https://github.com/user-attachments/assets/ef8a61b7-6b99-49a1-9767-af94b9c2c4e2)
+
+
 ```ruby
 class ReadyOrders < Sourced::Projector::StateStored
   # Fetch listing record from DB, or new one.

--- a/examples/cart.rb
+++ b/examples/cart.rb
@@ -220,8 +220,9 @@ class LoggingReactor
     # to be dispatched to the appropriate command handlers.
     #
     # @param events [Array<Message>]
+    # @option replaying [Boolean] whether this is a replay of events
     # @return [Array<Message]
-    def handle_events(events)
+    def handle_events(events, replaying:)
       puts "LoggingReactor received #{events}"
       []
     end

--- a/lib/sourced/actor.rb
+++ b/lib/sourced/actor.rb
@@ -384,7 +384,7 @@ module Sourced
       #
       #  reaction_with_state SomethingHappened do |state, event|
       #    if seq == event.seq # event is the last one to have happened.
-      #      command DoSomething
+      #      stream_for(event).command DoSomething
       #    else
       #      # ignore ?
       #    end

--- a/lib/sourced/actor.rb
+++ b/lib/sourced/actor.rb
@@ -369,7 +369,7 @@ module Sourced
       #    state[:count] += 1
       #  end
       #
-      #  react_with_state SomethingHappened do |state, event|
+      #  reaction_with_state SomethingHappened do |state, event|
       #    if state[:count] % 3 == 0
       #      command NotifyEachThirdTime
       #    end
@@ -394,16 +394,16 @@ module Sourced
       # @yield [Object, Sourced::Event]
       # @return [void]
       def reaction_with_state(event_name, &block)
-        raise ArgumentError, 'react_with_state expects a block' unless block_given?
+        raise ArgumentError, '.reaction_with_state expects a block' unless block_given?
 
         event_class = if event_name.is_a?(Symbol)
           self::Event.registry[__message_type(event_name)]
         else
           event_name
         end
-        raise ArgumentError, '.react_with_state expects a block with |state, event|' unless block.arity == 2
+        raise ArgumentError, '.reaction_with_state expects a block with |state, event|' unless block.arity == 2
         unless handled_events_for_evolve.include?(event_class)
-          raise ArgumentError, '.react_with_state only works with event types handled by this class via .event(event_type)' 
+          raise ArgumentError, '.reaction_with_state only works with event types handled by this class via .event(event_type)' 
         end
 
         method_name = Sourced.message_method_name(REACTION_WITH_STATE_PREFIX, event_class.to_s)

--- a/lib/sourced/actor.rb
+++ b/lib/sourced/actor.rb
@@ -192,8 +192,9 @@ module Sourced
       # Any commands returned will be schedule to run next.
       #
       # @param events [Array<Sourced::Event>]
+      # @option replaying [Boolean] if true, the events are being replayed
       # @return [Array<Sourced::Command>]
-      def handle_events(events)
+      def handle_events(events, replaying: false)
         load(events.first.stream_id).handle_events(events)
       end
 

--- a/lib/sourced/backends/test_backend.rb
+++ b/lib/sourced/backends/test_backend.rb
@@ -71,7 +71,7 @@ module Sourced
         end
 
         def reindex
-          backend.events.each.with_index do |e, idx|
+          backend.events.each do |e|
             @offsets[e.stream_id] ||= Offset.new(e.stream_id, -1, false)
           end
         end

--- a/lib/sourced/evolve.rb
+++ b/lib/sourced/evolve.rb
@@ -70,8 +70,8 @@ module Sourced
 
       # The Reactor interface
       # expected by Worker
-      def handle_events(_events)
-        raise NoMethodError, "implement .handle_events(Array<Event>) in #{self}"
+      def handle_events(_events, replaying: false)
+        raise NotImplementedError, "implement .handle_events(Array<Event>, replaying: Boolean) in #{self}"
       end
 
       def handled_events_for_evolve

--- a/lib/sourced/projector.rb
+++ b/lib/sourced/projector.rb
@@ -30,6 +30,14 @@ module Sourced
       end
 
       private :reaction
+
+      def reaction_with_state(event_class, &block)
+        unless handled_events_for_evolve.include?(event_class)
+          raise ArgumentError, '.reaction_with_state only works with event types handled by this class via .event(event_type)' 
+        end
+
+        super
+      end
     end
 
     attr_reader :id, :seq, :state

--- a/lib/sourced/projector.rb
+++ b/lib/sourced/projector.rb
@@ -31,8 +31,8 @@ module Sourced
 
       private :reaction
 
-      def reaction_with_state(event_class, &block)
-        unless handled_events_for_evolve.include?(event_class)
+      def reaction_with_state(event_class = nil, &block)
+        if event_class && !handled_events_for_evolve.include?(event_class)
           raise ArgumentError, '.reaction_with_state only works with event types handled by this class via .event(event_type)' 
         end
 

--- a/lib/sourced/projector.rb
+++ b/lib/sourced/projector.rb
@@ -41,7 +41,7 @@ module Sourced
       %(<#{self.class} id:#{id} seq:#{seq}>)
     end
 
-    def handle_events(events)
+    def handle_events(events, replaying:)
       evolve(state, events)
       save(state, events)
       [] # no commands
@@ -85,9 +85,9 @@ module Sourced
     #  end
     class StateStored < self
       class << self
-        def handle_events(events)
+        def handle_events(events, replaying: false)
           instance = new(events.first.stream_id)
-          instance.handle_events(events)
+          instance.handle_events(events, replaying:)
         end
       end
     end
@@ -116,11 +116,11 @@ module Sourced
     #  end
     class EventSourced < self
       class << self
-        def handle_events(events)
+        def handle_events(events, replaying: false)
           # The current state already includes
           # the new events, so we need to load upto events.first.seq
           instance = load(events.first.stream_id, upto: events.first.seq - 1)
-          instance.handle_events(events)
+          instance.handle_events(events, replaying:)
         end
 
         # Load from event history

--- a/lib/sourced/react.rb
+++ b/lib/sourced/react.rb
@@ -130,8 +130,8 @@ module Sourced
 
       # These two are the Reactor interface
       # expected by Worker
-      def handle_events(_events)
-        raise NoMethodError, "implement .handle_events(Array<Event>) in #{self}"
+      def handle_events(_events, replaying: false)
+        raise NotImplementedError, "implement .handle_events(Array<Event>, replaying: Boolean) in #{self}"
       end
 
       def handled_events_for_react

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -167,9 +167,9 @@ module Sourced
     end
 
     def handle_next_event_for_reactor(reactor, process_name = nil)
-      backend.reserve_next_for_reactor(reactor) do |event|
+      backend.reserve_next_for_reactor(reactor) do |event, replaying|
         log_event('handling event', reactor, event, process_name)
-        commands = reactor.handle_events([event])
+        commands = reactor.handle_events([event], replaying:)
         if commands.any?
           # TODO: this schedules commands that will be picked up
           # by #dispatch_next_command above on the worker's next tick

--- a/lib/sourced/router.rb
+++ b/lib/sourced/router.rb
@@ -161,7 +161,6 @@ module Sourced
     def handle_next_event_for_reactor(reactor, process_name = nil)
       backend.reserve_next_for_reactor(reactor) do |event|
         log_event('handling event', reactor, event, process_name)
-        #  TODO: handle exceptions here
         commands = reactor.handle_events([event])
         if commands.any?
           # TODO: this schedules commands that will be picked up

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -399,7 +399,7 @@ RSpec.describe Sourced::Actor do
     end
   end
 
-  describe '.reaction_with_state for own events' do
+  describe '.reaction with state for own events' do
     let(:klass) do
       Class.new(Sourced::Actor) do
         consumer do |c|
@@ -419,6 +419,8 @@ RSpec.describe Sourced::Actor do
           state[1] = :done
         end
 
+        # Two arguments to reaction, the first is the state
+        # this will cause the actor to load state from past events
         reaction :thing_done do |state, event|
           stream_for(event).command :notify, value: "seq was #{seq}, state was #{state[1]}, name was #{event.payload.name}"
           return # <= should not raise LocalJumpError
@@ -454,7 +456,7 @@ RSpec.describe Sourced::Actor do
     end
   end
 
-  describe '.reaction_with_state for all own events' do
+  describe '.reaction with state for all own events' do
     let(:klass) do
       Class.new(Sourced::Actor) do
         state do |id|

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe Sourced::Actor do
           state[1] = :done
         end
 
-        reaction_with_state :thing_done do |state, event|
+        reaction :thing_done do |state, event|
           stream_for(event).command :notify, value: "seq was #{seq}, state was #{state[1]}, name was #{event.payload.name}"
           return # <= should not raise LocalJumpError
         end
@@ -449,13 +449,7 @@ RSpec.describe Sourced::Actor do
 
     it 'fails to register reaction if event is not handled by the same Actor' do
       expect do
-        klass.reaction_with_state(TestActor::ListStarted) { |_state, _event| }
-      end.to raise_error(ArgumentError)
-    end
-
-    it 'fails to register reaction if block does not support |state, event|' do
-      expect do
-        klass.reaction_with_state(TestActor::ListStarted) { |_state| }
+        klass.reaction(TestActor::ListStarted) { |_state, _event| }
       end.to raise_error(ArgumentError)
     end
   end
@@ -478,7 +472,7 @@ RSpec.describe Sourced::Actor do
         command :notify, value: String do |_state, _cmd|
         end
 
-        reaction_with_state do |state, event|
+        reaction do |state, event|
           stream_for(event).command :notify, value: "seq was #{seq}, state was #{state[1]}, name was #{event.payload.name}"
         end
       end

--- a/spec/actor_spec.rb
+++ b/spec/actor_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe Sourced::Actor do
 
   specify '.handle_events' do
     evt = TestActor::TodoListActor::ItemAdded.parse(stream_id: 'list1', payload: { name: 'item1' })
-    commands = TestActor::TodoListActor.handle_events([evt])
+    commands = TestActor::TodoListActor.handle_events([evt], replaying: false)
     expect(commands.map(&:class)).to eq([TestActor::Notify])
     expect(commands.first.stream_id).to eq('list1')
     expect(commands.first.causation_id).to eq(evt.id)

--- a/spec/projector_spec.rb
+++ b/spec/projector_spec.rb
@@ -61,14 +61,14 @@ module ProjectorTest
     event Probed # register so that it's handled by .reaction_with_state
 
     # React to a specific event
-    reaction_with_state Added do |state, event|
+    reaction Added do |state, event|
       if state.total > 20
         stream_for(event).command NextCommand, amount: state.total
       end
     end
 
     # React to any event
-    reaction_with_state do |state, event|
+    reaction do |state, event|
       if state.total > 10
         stream_for(event).command NextCommand2, amount: state.total
       end
@@ -146,7 +146,7 @@ RSpec.describe Sourced::Projector do
     it 'rejects reactions to events not handled by .event handlers' do
       expect {
         Class.new(Sourced::Projector::StateStored) do
-          reaction_with_state ProjectorTest::Added do |_state, _event|
+          reaction ProjectorTest::Added do |_state, _event|
           end
         end
       }.to raise_error(ArgumentError)

--- a/spec/projector_spec.rb
+++ b/spec/projector_spec.rb
@@ -118,6 +118,15 @@ RSpec.describe Sourced::Projector do
       expect(commands).to eq([])
       expect(ProjectorTest::STORE['222'].total).to eq(22)
     end
+
+    it 'rejects reactions to events not handled by .event handlers' do
+      expect {
+        Class.new(Sourced::Projector::StateStored) do
+          reaction_with_state ProjectorTest::Added do |_state, _event|
+          end
+        end
+      }.to raise_error(ArgumentError)
+    end
   end
 
   describe Sourced::Projector::EventSourced do

--- a/spec/projector_spec.rb
+++ b/spec/projector_spec.rb
@@ -58,7 +58,7 @@ module ProjectorTest
       state.total += event.payload.amount
     end
 
-    event Probed # register so that it's handled by .reaction_with_state
+    event Probed # register so that it's handled by .reaction
 
     # React to a specific event
     reaction Added do |state, event|

--- a/spec/projector_spec.rb
+++ b/spec/projector_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Sourced::Projector do
       e1 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 10 })
       e2 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 5 })
 
-      ProjectorTest::StateStored.handle_events([e1, e2])
+      ProjectorTest::StateStored.handle_events([e1, e2], replaying: false)
 
       expect(ProjectorTest::STORE['111'].total).to eq(15)
     end
@@ -65,7 +65,7 @@ RSpec.describe Sourced::Projector do
       e1 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 10 })
       e2 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 5 })
 
-      ProjectorTest::StateStored.handle_events([e1, e2])
+      ProjectorTest::StateStored.handle_events([e1, e2], replaying: false)
 
       expect(ProjectorTest::STORE['111'].total).to eq(25)
     end
@@ -80,7 +80,7 @@ RSpec.describe Sourced::Projector do
       e1 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 10 })
       e2 = ProjectorTest::Added.parse(stream_id: '111', payload: { amount: 5 })
 
-      result = ProjectorTest::EventSourced.handle_events([e1, e2])
+      result = ProjectorTest::EventSourced.handle_events([e1, e2], replaying: false)
 
       expect(result).to eq([])
       obj, last_event_type = ProjectorTest::STORE['111']
@@ -95,7 +95,7 @@ RSpec.describe Sourced::Projector do
 
       Sourced.config.backend.append_to_stream('111', [e1])
 
-      result = ProjectorTest::EventSourced.handle_events([e2, e3])
+      result = ProjectorTest::EventSourced.handle_events([e2, e3], replaying: false)
 
       expect(result).to eq([])
       obj, last_event_type = ProjectorTest::STORE['111']


### PR DESCRIPTION
* Refactor `.reaction` blocks so that they can load state, optionally (no need for a separate `.reaction_with_state`)
* Make projectors support `.reaction` so that they can implement TODO list style automations supported by persisted state.
* Extend backend API so that it tracks each consumer groups' highest acknowledged event sequence and uses that to asses whether the reactors are being "replayed" or processing new events for the first time.

#### `Actor.reaction` block with actor state

If the block to `.reaction`  defines two arguments, this will cause Sourced to load up and yield the Actor's current state by loading and applying past events to it (same as when handling commands).

For this reason,  in this mode `.reaction` can only be used with events that are also registered to _evolve_ the same Actor.

```ruby
# Define an event handler to evolve state
event ItemAdded do |state, event|
  state[:item_count] += 1
end

# Now react to it and check state
reaction ItemAdded do |state, event|
  if state[:item_count] > 30
    stream_for(event).command NotifyBigCart
  end
end
```

##### `Actor.reaction` with state for all events

If the event name or class is omitted, the `.reaction` macro registers reaction handlers for all events already registered for the actor with the `.event` macro, minus events that have specific reaction handlers defined.

```ruby
# wildcard reaction for all evolved events
reaction do |state, event|
  if state[:item_count] > 30
    stream_for(event).command NotifyBigCart
  end
end
```

#### Projectors reacting to events and scheduling the next command from projectors

Sourced projectors can define `.reaction` handlers that will be called after evolving state via their `.event` handlers, in the same transaction.

This can be useful to implement TODO List patterns where a projector persists projected data, and then reacts to the data update using the data to schedule the next command in a workflow.

![CleanShot 2025-05-30 at 18 20 20](https://github.com/user-attachments/assets/6ef4b654-b247-412d-8a86-2c7ab39948f9)

```ruby
class ReadyOrders < Sourced::Projector::StateStored
  # Fetch listing record from DB, or new one.
  state do |id|
    OrderListing.find_or_initialize(id)
  end

  event Orders::ItemAdded do |listing, event|
    listing.line_items << event.payload
  end
  
  # Evolve listing record from events
  event Orders::PaymentConfirmed do |listing, event|
    listing.payment_confirmed = true
  end

  event Orders::BuildConfirmed do |listing, event|
    listing.build_confirmed = true
  end
  
  # Sync listing record back to DB
  sync do |listing, _, _|
    listing.save!
  end
  
  # If a listing has both the build and payment confirmed,
  # automate dispatching the next command in the workflow
  reaction do |listing, event|
    if listing.payment_confirmed? && listing.build_confirmed?
      stream_for(event).command Orders::Release, **listing.attributes
    end
  end
end
```

Projectors can also define `.reaction event_class do |state, event|` to react to specific events.

##### Skipping projector reactions when replaying events

When a projector's offsets are reset (so that it starts re-processing events and re- building projections), Sourced skips invoking a projector's `.reaction` handlers. This is because building projections should be deterministic, and rebuilding them should not trigger side-effects such as automation (we don't want to call 3rd party APIs, send emails, or just dispatch the same commands over and over when rebuilding projections).

To do this, Sourced keeps track of each consumer groups' highest acknowledged event sequence. When a consumer group is reset and starts re-processing past events, this sequence number is compared with each event's sequence, which tells us whether the event has been processed before.

For this, the `Backend.reserve_next_for_reactor` API now yields a `:replaying` boolean.

```ruby
backend.reserve_next_for_reactor(reactor) do |event, replaying:|
  # :replaying is true if this event is being replayed by the reactor's consumer group
  # It's up to reactor implementations to handle or ignore this flag
  reactor.handle_events([event], replaying:)
end
```