### PR TITLE
Add Backend#recent_streams method for monitoring stream activity

### DIFF
--- a/lib/sourced/backends/sequel_backend.rb
+++ b/lib/sourced/backends/sequel_backend.rb
@@ -170,6 +170,41 @@ module Sourced
         Stats.new(stream_count, max_global_seq, groups)
       end
 
+      # Data structure representing a stream with its metadata.
+      # @!attribute [r] stream_id
+      #   @return [String] Unique identifier for the stream
+      # @!attribute [r] seq
+      #   @return [Integer] Latest sequence number in the stream
+      # @!attribute [r] updated_at
+      #   @return [Time] Timestamp of the most recent event in the stream
+      Stream = Data.define(:stream_id, :seq, :updated_at)
+
+      # Retrieve a list of recently active streams, ordered by most recent activity.
+      # This method is useful for diagnostics, monitoring, and debugging to understand
+      # which streams have been most active in the system.
+      #
+      # @param limit [Integer] Maximum number of streams to return (defaults to 10)
+      # @return [Array<Stream>] Array of Stream objects ordered by updated_at descending
+      # @example Get the 5 most recently active streams
+      #   recent = backend.recent_streams(limit: 5)
+      #   recent.each do |stream|
+      #     puts "Stream #{stream.stream_id}: seq #{stream.seq} at #{stream.updated_at}"
+      #   end
+      # @example Monitor system activity
+      #   streams = backend.recent_streams(limit: 20)
+      #   active_count = streams.count { |s| s.updated_at > 1.hour.ago }
+      #   puts "#{active_count} streams active in last hour"
+      def recent_streams(limit: 10)
+        query = db[streams_table]
+          .select(:stream_id, :seq, :updated_at)
+          .order(Sequel.desc(:updated_at))
+          .limit(limit)
+
+        query.map do |row|
+          Stream.new(**row)
+        end
+      end
+
       def transaction(&)
         db.transaction(&)
       end


### PR DESCRIPTION
Implements a new backend method to retrieve recently active streams ordered by their last update time. This feature is useful for:

- System monitoring and diagnostics
- Debugging stream activity patterns
- Understanding which entities are most active
- Building administrative dashboards

## Implementation Details

- **SequelBackend**: Queries streams table with SQL ORDER BY updated_at DESC
- **TestBackend**: Maintains in-memory stream metadata with timestamp tracking
- **Stream Data Structure**: Contains stream_id, seq, and updated_at fields
- **Configurable Limit**: Defaults to 10 streams, customizable via parameter

## Features

- Consistent interface across all backend implementations
- Comprehensive YARD documentation with usage examples
- Full test coverage with shared examples for backend compliance
- Time-based ordering ensures most active streams appear first

## Usage

```ruby
# Get 5 most recent streams
recent = backend.recent_streams(limit: 5)
recent.each { |s| puts "#{s.stream_id}: #{s.seq} at #{s.updated_at}" }

# Monitor system activity
active_count = backend.recent_streams(limit: 50)
  .count { |s| s.updated_at > 1.hour.ago }
```

🤖 Generated with [Claude Code](https://claude.ai/code)